### PR TITLE
feat(contract): percentage math utilities (basis points, rounding-safe) + comprehensive tests

### DIFF
--- a/contract/src/base/mod.rs
+++ b/contract/src/base/mod.rs
@@ -1,3 +1,4 @@
 pub mod errors;
 pub mod events;
 pub mod types;
+pub mod utils;

--- a/contract/src/base/utils.rs
+++ b/contract/src/base/utils.rs
@@ -1,0 +1,61 @@
+use crate::base::errors::AutoShareError;
+use crate::base::types::GroupMember;
+use soroban_sdk::{Env, Vec};
+
+/// Calculates a member's share: total * percentage / 10000.
+/// Uses checked multiplication to prevent overflow issues on large total amounts.
+pub fn calculate_share(total: i128, percentage: u32) -> i128 {
+    total
+        .checked_mul(percentage as i128)
+        .expect("overflow in calculate_share")
+        / 10000
+}
+
+/// Validates that the percentages (basis points) of all members sum to exactly 10000 (100%).
+pub fn validate_percentages(members: &Vec<GroupMember>) -> Result<(), AutoShareError> {
+    let mut sum: u32 = 0;
+    for member in members.iter() {
+        sum = sum
+            .checked_add(member.percentage)
+            .ok_or(AutoShareError::InvalidPercentage)?;
+    }
+    if sum == 10000 {
+        Ok(())
+    } else {
+        Err(AutoShareError::InvalidPercentage)
+    }
+}
+
+/// Splits total by basis points with deterministic remainder handling so payouts sum exactly to total.
+/// Rounds down using floor division and assigns any remaining dust to the last member.
+/// Returns `AutoShareError::InvalidAmount` if the total is negative.
+/// Returns `AutoShareError::InvalidPercentage` if the member percentages do not validate correctly.
+pub fn distribute_amounts(
+    env: &Env,
+    total: i128,
+    members: &Vec<GroupMember>,
+) -> Result<Vec<i128>, AutoShareError> {
+    if total < 0 {
+        return Err(AutoShareError::InvalidAmount);
+    }
+
+    validate_percentages(members)?;
+
+    let mut distributed: i128 = 0;
+    let mut shares = Vec::new(env);
+    let len = members.len();
+
+    for i in 0..len {
+        let member = members.get(i).unwrap();
+        let share = if i == len - 1 {
+            // The last member explicitly gets the remaining dust to ensure payouts sum exactly to the total.
+            total - distributed
+        } else {
+            calculate_share(total, member.percentage)
+        };
+        shares.push_back(share);
+        distributed += share;
+    }
+
+    Ok(shares)
+}

--- a/contract/src/interfaces/autoshare.rs
+++ b/contract/src/interfaces/autoshare.rs
@@ -19,4 +19,15 @@ pub trait AutoShareTrait {
     fn get_groups_by_creator(env: Env, creator: Address) -> Vec<AutoShareDetails>;
 
     fn distribute(env: Env, caller: Address, group_id: BytesN<32>, total_amount: i128);
+
+    /// Pure view: returns the share amounts each member of a group would receive
+    /// for `total_amount`, applying the same rounding logic as `distribute`.
+    /// Does NOT transfer any tokens.
+    fn get_member_shares(env: Env, group_id: BytesN<32>, total_amount: i128) -> Vec<i128>;
+
+    /// Pure view: returns `total * percentage / 10_000` for arbitrary inputs.
+    fn get_calculated_share(env: Env, total: i128, percentage: u32) -> i128;
+
+    /// Pure view: returns the total percentage (basis points) of all members in a group.
+    fn get_total_percentage(env: Env, group_id: BytesN<32>) -> u32;
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -142,11 +142,7 @@ impl AutoShareContract {
     /// Returns the computed share each member would receive for `total_amount`,
     /// using the same floor-division + last-member-dust logic as `distribute`.
     /// This is a pure read: no tokens are moved.
-    pub fn get_member_shares(
-        env: Env,
-        group_id: BytesN<32>,
-        total_amount: i128,
-    ) -> Vec<i128> {
+    pub fn get_member_shares(env: Env, group_id: BytesN<32>, total_amount: i128) -> Vec<i128> {
         let details: AutoShareDetails = env
             .storage()
             .persistent()

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -70,12 +70,7 @@ impl AutoShareContract {
         if details.creator != caller {
             panic!("only the creator can update members");
         }
-
-        let mut total: u32 = 0;
-        for m in new_members.iter() {
-            total += m.percentage;
-        }
-        if total != 10000 {
+        if base::utils::validate_percentages(&new_members).is_err() {
             panic!("percentages must sum to 10000");
         }
 
@@ -133,21 +128,54 @@ impl AutoShareContract {
 
         // Transfer full amount from caller to contract first
         token_client.transfer(&caller, &contract_address, &total_amount);
-
-        let mut distributed: i128 = 0;
-        let member_count = details.members.len();
+        let shares = base::utils::distribute_amounts(&env, total_amount, &details.members)
+            .expect("failed to distribute amounts");
 
         for (i, member) in details.members.iter().enumerate() {
-            let share = if i as u32 == member_count - 1 {
-                // Last member gets the remainder to handle rounding dust
-                total_amount - distributed
-            } else {
-                total_amount * (member.percentage as i128) / 10000
-            };
+            let share = shares.get(i as u32).unwrap();
             token_client.transfer(&contract_address, &member.address, &share);
-            distributed += share;
         }
 
         events::distribution_processed(&env, &group_id, total_amount);
+    }
+
+    /// Returns the computed share each member would receive for `total_amount`,
+    /// using the same floor-division + last-member-dust logic as `distribute`.
+    /// This is a pure read: no tokens are moved.
+    pub fn get_member_shares(
+        env: Env,
+        group_id: BytesN<32>,
+        total_amount: i128,
+    ) -> Vec<i128> {
+        let details: AutoShareDetails = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Group(group_id))
+            .expect("group not found");
+
+        base::utils::distribute_amounts(&env, total_amount, &details.members)
+            .expect("invalid group configuration")
+    }
+
+    /// Returns `total * percentage / 10_000` for any arbitrary inputs.
+    /// Useful for ad-hoc share preview before calling distribute.
+    pub fn get_calculated_share(_env: Env, total: i128, percentage: u32) -> i128 {
+        base::utils::calculate_share(total, percentage)
+    }
+
+    /// Returns the sum of all member percentages (in basis points) for a group.
+    /// A healthy group should always return 10000.
+    pub fn get_total_percentage(env: Env, group_id: BytesN<32>) -> u32 {
+        let details: AutoShareDetails = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Group(group_id))
+            .expect("group not found");
+
+        let mut sum: u32 = 0;
+        for member in details.members.iter() {
+            sum = sum.saturating_add(member.percentage);
+        }
+        sum
     }
 }

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -244,3 +244,343 @@ fn test_distribute_insufficient_balance() {
 
     client.distribute(&creator, &id, &1000);
 }
+
+// ── percentage utility tests ───────────────────────────────────────────────
+
+#[test]
+fn test_calculate_share_normal() {
+    let share = base::utils::calculate_share(1000, 2500);
+    assert_eq!(share, 250);
+}
+
+#[test]
+fn test_calculate_share_zero() {
+    let share = base::utils::calculate_share(1000, 0);
+    assert_eq!(share, 0);
+}
+
+#[test]
+fn test_calculate_share_full() {
+    let share = base::utils::calculate_share(1000, 10000);
+    assert_eq!(share, 1000);
+}
+
+#[test]
+fn test_validate_percentages_ok() {
+    let env = Env::default();
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 6000,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Bob"),
+            percentage: 4000,
+        },
+    ];
+    let res = base::utils::validate_percentages(&members);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_validate_percentages_too_low() {
+    let env = Env::default();
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 5000,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Bob"),
+            percentage: 4999,
+        },
+    ];
+    let res = base::utils::validate_percentages(&members);
+    assert_eq!(res, Err(base::errors::AutoShareError::InvalidPercentage));
+}
+
+#[test]
+fn test_validate_percentages_too_high() {
+    let env = Env::default();
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 5000,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Bob"),
+            percentage: 5001,
+        },
+    ];
+    let res = base::utils::validate_percentages(&members);
+    assert_eq!(res, Err(base::errors::AutoShareError::InvalidPercentage));
+}
+
+#[test]
+fn test_validate_percentages_zero() {
+    let env = Env::default();
+    let members = soroban_sdk::Vec::new(&env);
+    let res = base::utils::validate_percentages(&members);
+    assert_eq!(res, Err(base::errors::AutoShareError::InvalidPercentage));
+}
+
+#[test]
+fn test_distribute_amounts_even() {
+    let env = Env::default();
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 5000,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Bob"),
+            percentage: 5000,
+        },
+    ];
+    let res = base::utils::distribute_amounts(&env, 1000, &members).unwrap();
+    assert_eq!(res.len(), 2);
+    assert_eq!(res.get(0).unwrap(), 500);
+    assert_eq!(res.get(1).unwrap(), 500);
+}
+
+#[test]
+fn test_distribute_amounts_indivisible() {
+    let env = Env::default();
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 3333,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Bob"),
+            percentage: 3333,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Charlie"),
+            percentage: 3334,
+        },
+    ];
+    let res = base::utils::distribute_amounts(&env, 100, &members).unwrap();
+    assert_eq!(res.len(), 3);
+    let a = res.get(0).unwrap();
+    let b = res.get(1).unwrap();
+    let c = res.get(2).unwrap();
+    assert_eq!(a, 33);
+    assert_eq!(b, 33);
+    assert_eq!(c, 34); // gets the remaining dust
+    assert_eq!(a + b + c, 100);
+}
+
+#[test]
+fn test_distribute_amounts_single() {
+    let env = Env::default();
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 10000,
+        },
+    ];
+    let res = base::utils::distribute_amounts(&env, 12345, &members).unwrap();
+    assert_eq!(res.len(), 1);
+    assert_eq!(res.get(0).unwrap(), 12345);
+}
+
+#[test]
+fn test_distribute_amounts_many() {
+    let env = Env::default();
+    let mut members = soroban_sdk::Vec::new(&env);
+    for _ in 0..10 {
+        members.push_back(GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Member"),
+            percentage: 1000,
+        });
+    }
+    let res = base::utils::distribute_amounts(&env, 100000, &members).unwrap();
+    assert_eq!(res.len(), 10);
+    let mut sum = 0;
+    for val in res.iter() {
+        sum += val;
+        assert_eq!(val, 10000);
+    }
+    assert_eq!(sum, 100000);
+}
+
+#[test]
+fn test_distribute_amounts_large() {
+    let env = Env::default();
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 6000,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Bob"),
+            percentage: 4000,
+        },
+    ];
+    // A large i128 total amount (e.g. 10^30)
+    let total: i128 = 1_000_000_000_000_000_000_000_000_000_000i128;
+    let res = base::utils::distribute_amounts(&env, total, &members).unwrap();
+    assert_eq!(res.len(), 2);
+    let a = res.get(0).unwrap();
+    let b = res.get(1).unwrap();
+    assert_eq!(a, 600_000_000_000_000_000_000_000_000_000i128);
+    assert_eq!(b, 400_000_000_000_000_000_000_000_000_000i128);
+    assert_eq!(a + b, total);
+}
+
+#[test]
+fn test_distribute_amounts_negative() {
+    let env = Env::default();
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 10000,
+        },
+    ];
+    let res = base::utils::distribute_amounts(&env, -100, &members);
+    assert_eq!(res, Err(base::errors::AutoShareError::InvalidAmount));
+}
+
+#[test]
+fn test_distribute_amounts_one() {
+    let env = Env::default();
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 5000,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Bob"),
+            percentage: 5000,
+        },
+    ];
+    let res = base::utils::distribute_amounts(&env, 1, &members).unwrap();
+    assert_eq!(res.len(), 2);
+    assert_eq!(res.get(0).unwrap(), 0);
+    assert_eq!(res.get(1).unwrap(), 1); // gets the remaining dust unit
+}
+
+#[test]
+fn test_distribute_amounts_zero() {
+    let env = Env::default();
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 5000,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Bob"),
+            percentage: 5000,
+        },
+    ];
+    let res = base::utils::distribute_amounts(&env, 0, &members).unwrap();
+    assert_eq!(res.len(), 2);
+    assert_eq!(res.get(0).unwrap(), 0);
+    assert_eq!(res.get(1).unwrap(), 0);
+}
+
+#[test]
+fn test_validate_percentages_large_list() {
+    let env = Env::default();
+    let mut members = soroban_sdk::Vec::new(&env);
+    for _ in 0..100 {
+        members.push_back(GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Member"),
+            percentage: 100, // 100 members * 100 basis points = 10000 (100%)
+        });
+    }
+    let res = base::utils::validate_percentages(&members);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_get_member_shares_even() {
+    let (env, client, creator, token) = setup_env();
+    let id = BytesN::from_array(&env, &[1u8; 32]);
+    client.create(&id, &String::from_str(&env, "Group"), &creator, &1, &token);
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 6000,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Bob"),
+            percentage: 4000,
+        },
+    ];
+    client.update_members(&id, &creator, &members);
+    let shares = client.get_member_shares(&id, &1000);
+    assert_eq!(shares.len(), 2);
+    assert_eq!(shares.get(0).unwrap(), 600);
+    assert_eq!(shares.get(1).unwrap(), 400);
+}
+
+#[test]
+fn test_get_calculated_share() {
+    let (env, client, _, _) = setup_env();
+    let share = client.get_calculated_share(&1000, &2500);
+    assert_eq!(share, 250);
+}
+
+#[test]
+fn test_get_total_percentage() {
+    let (env, client, creator, token) = setup_env();
+    let id = BytesN::from_array(&env, &[2u8; 32]);
+    client.create(&id, &String::from_str(&env, "Group2"), &creator, &1, &token);
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "A"),
+            percentage: 3333,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "B"),
+            percentage: 3333,
+        },
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "C"),
+            percentage: 3334,
+        },
+    ];
+    client.update_members(&id, &creator, &members);
+    let total = client.get_total_percentage(&id);
+    assert_eq!(total, 10000);
+}

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -552,7 +552,7 @@ fn test_get_member_shares_even() {
 
 #[test]
 fn test_get_calculated_share() {
-    let (env, client, _, _) = setup_env();
+    let (_env, client, _, _) = setup_env();
     let share = client.get_calculated_share(&1000, &2500);
     assert_eq!(share, 250);
 }

--- a/contract/test_snapshots/test/test_distribute_group_not_found.1.json
+++ b/contract/test_snapshots/test/test_distribute_group_not_found.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contract/test_snapshots/test/test_distribute_zero_amount.1.json
+++ b/contract/test_snapshots/test/test_distribute_zero_amount.1.json
@@ -1,0 +1,283 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create",
+              "args": [
+                {
+                  "bytes": "1414141414141414141414141414141414141414141414141414141414141414"
+                },
+                {
+                  "string": "G"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u32": 1
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CreatorGroups"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CreatorGroups"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "1414141414141414141414141414141414141414141414141414141414141414"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Group"
+                },
+                {
+                  "bytes": "1414141414141414141414141414141414141414141414141414141414141414"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Group"
+                    },
+                    {
+                      "bytes": "1414141414141414141414141414141414141414141414141414141414141414"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "creator"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "id"
+                      },
+                      "val": {
+                        "bytes": "1414141414141414141414141414141414141414141414141414141414141414"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "members"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": "G"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "payment_token"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "usage_count"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contract/test_snapshots/test/test_get_calculated_share.1.json
+++ b/contract/test_snapshots/test/test_get_calculated_share.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
## Pull Request: `math_util`

### Summary
This PR introduces a robust set of percentage‑based math utilities for the **PaymeshStellar** smart‑contract and exposes them via the contract’s public API. It also adds comprehensive unit tests and cleans up lint warnings.

### What’s Changed
| Area                | Description |
|---------------------|-------------|
| **Core Utilities**  | Added `calculate_share`, `validate_percentages`, and `distribute_amounts` in `contract/src/base/utils.rs`. |
| **Contract Interface** | Extended `AutoShareTrait` with three pure‑view getter methods:<br/>• `get_member_shares` – computes member shares for a given total.<br/>• `get_calculated_share` – performs `total * percentage / 10_000` safely.<br/>• `get_total_percentage` – returns the sum of all member percentages. |
| **Contract Implementation** | Implemented the new getters in `contract/src/lib.rs` using the utilities, ensuring no token transfers occur. |
| **Tests** | Added unit tests for the new getters (`test_get_member_shares_even`, `test_get_calculated_share`, `test_get_total_percentage`) and updated existing suite. All **28 tests pass**. |
| **Linting** | Fixed a manual saturating‑arithmetic warning (`checked_add → saturating_add`) – `cargo clippy` now reports **zero warnings**. |
| **Documentation** | Updated trait and implementation comments to describe the new view functions. |

### Related Issue
- Closes #70  – “percentage math utilities (basis points, rounding‑safe) + comprehensive tests”.

### Checklist
- [x] Add math utility functions.  
- [x] Expose getters in the contract interface.  
- [x] Implement getters in the contract.  
- [x] Write unit tests covering the new functionality.  
- [x] Run `cargo test` – all tests pass.  
- [x] Run `cargo clippy` – no warnings.  
- [x] Update documentation/comments accordingly.  

### Verification Steps
1. **Run tests**: `cargo test` – 28 passed.  
2. **Run clippy**: `cargo clippy` – clean.  
3. **Manual inspection**: Confirm getters return expected values via the new tests.  

### Additional Notes
- The getters are pure view functions; they do **not** modify state or transfer tokens, making them safe for off‑chain simulations.  
- Percentages are expressed in basis points (10 000 = 100 %).  

Please review and merge.
