### PR TITLE
feat(contract): add error variants and message() method

### DIFF
--- a/contract/src/base/errors.rs
+++ b/contract/src/base/errors.rs
@@ -13,4 +13,48 @@ pub enum AutoShareError {
     MemberNotFound = 7,
     DuplicateMember = 8,
     EmptyMembers = 9,
+    // Explicit variants requested by issue #54
+    UnauthorizedAccess = 10,
+    InvalidGroupId = 11,
+}
+
+impl AutoShareError {
+    /// Returns a short, actionable description of the error (≤ 100 characters).
+    pub fn message(&self) -> &'static str {
+        match self {
+            AutoShareError::GroupAlreadyExists => {
+                "Group already exists. Use a unique group ID."
+            }
+            AutoShareError::GroupNotFound => {
+                "Group not found. Verify the group ID is correct."
+            }
+            AutoShareError::Unauthorized => {
+                "Unauthorized. Only the group creator can perform this action."
+            }
+            AutoShareError::InvalidPercentage => {
+                "Invalid percentage. Member percentages must sum to 10000 basis points."
+            }
+            AutoShareError::InvalidAmount => {
+                "Invalid amount. Amount must be a positive integer greater than zero."
+            }
+            AutoShareError::InsufficientBalance => {
+                "Insufficient balance. Ensure the sender has enough funds to distribute."
+            }
+            AutoShareError::MemberNotFound => {
+                "Member not found. Verify the member address belongs to this group."
+            }
+            AutoShareError::DuplicateMember => {
+                "Duplicate member. Each member address must appear only once."
+            }
+            AutoShareError::EmptyMembers => {
+                "No members found. Add at least one member before distributing."
+            }
+            AutoShareError::UnauthorizedAccess => {
+                "Unauthorized access. You do not have permission to perform this action."
+            }
+            AutoShareError::InvalidGroupId => {
+                "Invalid group ID. The provided group ID does not exist or is malformed."
+            }
+        }
+    }
 }

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -1209,3 +1209,98 @@ fn test_get_total_percentage() {
     let total = client.get_total_percentage(&id);
     assert_eq!(total, 10000);
 }
+
+// ── error enum / message tests (issue #54) ────────────────────────────────
+
+#[test]
+fn test_error_messages_are_non_empty() {
+    let errors = [
+        AutoShareError::GroupAlreadyExists,
+        AutoShareError::GroupNotFound,
+        AutoShareError::Unauthorized,
+        AutoShareError::InvalidPercentage,
+        AutoShareError::InvalidAmount,
+        AutoShareError::InsufficientBalance,
+        AutoShareError::MemberNotFound,
+        AutoShareError::DuplicateMember,
+        AutoShareError::EmptyMembers,
+        AutoShareError::UnauthorizedAccess,
+        AutoShareError::InvalidGroupId,
+    ];
+    for err in errors.iter() {
+        let msg = err.message();
+        assert!(!msg.is_empty(), "message() must not be empty for {:?}", err);
+        assert!(
+            msg.len() <= 100,
+            "message() must be ≤ 100 chars for {:?}",
+            err
+        );
+    }
+}
+
+#[test]
+fn test_error_message_invalid_percentage() {
+    let err = AutoShareError::InvalidPercentage;
+    assert_eq!(
+        err.message(),
+        "Invalid percentage. Member percentages must sum to 10000 basis points."
+    );
+}
+
+#[test]
+fn test_error_message_member_not_found() {
+    let err = AutoShareError::MemberNotFound;
+    assert_eq!(
+        err.message(),
+        "Member not found. Verify the member address belongs to this group."
+    );
+}
+
+#[test]
+fn test_error_message_unauthorized_access() {
+    let err = AutoShareError::UnauthorizedAccess;
+    assert_eq!(
+        err.message(),
+        "Unauthorized access. You do not have permission to perform this action."
+    );
+}
+
+#[test]
+fn test_error_message_invalid_amount() {
+    let err = AutoShareError::InvalidAmount;
+    assert_eq!(
+        err.message(),
+        "Invalid amount. Amount must be a positive integer greater than zero."
+    );
+}
+
+#[test]
+fn test_error_message_invalid_group_id() {
+    let err = AutoShareError::InvalidGroupId;
+    assert_eq!(
+        err.message(),
+        "Invalid group ID. The provided group ID does not exist or is malformed."
+    );
+}
+
+#[test]
+fn test_unauthorized_access_variant_distinct_from_unauthorized() {
+    let a = AutoShareError::Unauthorized;
+    let b = AutoShareError::UnauthorizedAccess;
+    assert_ne!(a, b);
+    assert_ne!(a.message(), b.message());
+}
+
+#[test]
+fn test_invalid_group_id_variant_distinct_from_group_not_found() {
+    let a = AutoShareError::GroupNotFound;
+    let b = AutoShareError::InvalidGroupId;
+    assert_ne!(a, b);
+    assert_ne!(a.message(), b.message());
+}
+
+#[test]
+fn test_error_discriminants() {
+    assert_eq!(AutoShareError::UnauthorizedAccess as u32, 10);
+    assert_eq!(AutoShareError::InvalidGroupId as u32, 11);
+}


### PR DESCRIPTION
closes #54 

this PR added the following changes to the codebase:
- Add UnauthorizedAccess (discriminant 10) and InvalidGroupId (discriminant 11) variants to AutoShareError enum, covering every variant named in the issue
- Implement AutoShareError::message() returning a concise, actionable &'static str (≤ 100 chars) for every variant, guiding callers on how to resolve the failure
- Add 9 focused tests: exhaustive message-non-empty/length guard, per-variant exact-match assertions for the five issue-specified variants, distinctness checks between the new aliases and their legacy counterparts, and a discriminant-value guard to prevent accidental renumbering