### PR TITLE
feat(backend): off-chain PostgreSQL schema, migrations, and DB module

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,22 +2,17 @@ NODE_ENV=development
 PORT=3001
 CORS_ORIGIN=http://localhost:3000
 
-# Database
+# Database — PostgreSQL connection string (required for DB operations)
+# Docker quick-start: docker run -e POSTGRES_PASSWORD=password -p 5432:5432 postgres:16
 DATABASE_URL=postgresql://user:password@localhost:5432/paymesh
 
 # Auth
 JWT_SECRET=your-secret-key-min-32-chars
 
-# Stellar
+# Stellar / Horizon
 HORIZON_URL=https://horizon-testnet.stellar.org
-STELLAR_NETWORK=testnet
-
-# Horizon API URL (Testnet by default)
-HORIZON_URL=https://horizon-testnet.stellar.org
-# Stellar Network Passphrase (Testnet by default)
 STELLAR_NETWORK=Test SDF Network ; September 2015
-# Horizon Request Timeout (ms)
 HORIZON_TIMEOUT=30000
-# Horizon Cache TTL (ms)
 HORIZON_CACHE_TTL=30000
+
 LOG_LEVEL=debug

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,9 @@
     "format": "prettier --write \"src/**/*.{ts,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,json}\"",
     "type-check": "tsc --noEmit",
-    "test": "NODE_ENV=test node --test $(find dist -name '*.test.js' | tr '\n' ' ')"
+    "test": "NODE_ENV=test node --test $(find dist -name '*.test.js' | tr '\n' ' ')",
+    "db:migrate": "node dist/db/migrate.js",
+    "db:migrate:down": "node dist/db/migrate.js down"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^16.0.1",
@@ -20,12 +22,14 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "helmet": "^8.2.0",
+    "pg": "^8.11.3",
     "pino": "^10.3.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/node": "^20.10.5",
+    "@types/pg": "^8.11.6",
     "@types/supertest": "^7.2.0",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",

--- a/backend/src/db/__tests__/migrations.test.ts
+++ b/backend/src/db/__tests__/migrations.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Migration smoke tests + constraint tests.
+ *
+ * Requires a live PostgreSQL instance pointed to by DATABASE_URL.
+ * All tests are skipped automatically when DATABASE_URL is not set so the
+ * suite stays green in environments without a database.
+ *
+ * Run against a real DB:
+ *   DATABASE_URL=postgres://... pnpm --filter backend test
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Pool } from 'pg';
+import type { QueryResultRow } from 'pg';
+
+// ---------------------------------------------------------------------------
+// SQL — same statements as the migration files, inlined for test isolation.
+// ---------------------------------------------------------------------------
+
+const UP_SQL = `
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS users (
+  id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_address VARCHAR(64)  UNIQUE NOT NULL,
+  name           VARCHAR(255) NOT NULL,
+  email          VARCHAR(255),
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_users_wallet_address ON users (wallet_address);
+
+CREATE TABLE IF NOT EXISTS groups (
+  id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id       UUID         NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  name             VARCHAR(255) NOT NULL,
+  token            VARCHAR(64)  NOT NULL,
+  onchain_group_id VARCHAR(128) UNIQUE,
+  created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_groups_creator_id ON groups (creator_id);
+
+CREATE TABLE IF NOT EXISTS members (
+  id             UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id       UUID          NOT NULL REFERENCES groups (id) ON DELETE CASCADE,
+  member_address VARCHAR(64)   NOT NULL,
+  percentage     NUMERIC(7, 4) NOT NULL CHECK (percentage > 0 AND percentage <= 100),
+  joined_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_members_group_id       ON members (group_id);
+CREATE INDEX IF NOT EXISTS idx_members_member_address ON members (member_address);
+
+CREATE TABLE IF NOT EXISTS transactions (
+  id         UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id   UUID          NOT NULL REFERENCES groups (id) ON DELETE CASCADE,
+  amount     NUMERIC(30,7) NOT NULL,
+  asset      VARCHAR(64)   NOT NULL,
+  timestamp  TIMESTAMPTZ   NOT NULL,
+  tx_hash    VARCHAR(128)  UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_transactions_group_id  ON transactions (group_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_timestamp ON transactions (timestamp);
+`;
+
+const DOWN_SQL = `
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS members;
+DROP TABLE IF EXISTS groups;
+DROP TABLE IF EXISTS users;
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function tableExists(pool: Pool, tableName: string): Promise<boolean> {
+  interface Row extends QueryResultRow {
+    exists: boolean;
+  }
+  const res = await pool.query<Row>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = $1
+     ) AS exists`,
+    [tableName]
+  );
+  return res.rows[0]?.exists ?? false;
+}
+
+async function indexExists(pool: Pool, indexName: string): Promise<boolean> {
+  interface Row extends QueryResultRow {
+    exists: boolean;
+  }
+  const res = await pool.query<Row>(
+    `SELECT EXISTS (
+       SELECT 1 FROM pg_indexes
+       WHERE schemaname = 'public' AND indexname = $1
+     ) AS exists`,
+    [indexName]
+  );
+  return res.rows[0]?.exists ?? false;
+}
+
+// ---------------------------------------------------------------------------
+// Skip when no DB is available.
+// ---------------------------------------------------------------------------
+
+const skipReason: string | false = process.env.DATABASE_URL
+  ? false
+  : 'DATABASE_URL not configured';
+
+// ---------------------------------------------------------------------------
+// Migration smoke tests
+// ---------------------------------------------------------------------------
+
+describe('Migration smoke tests', { skip: skipReason }, () => {
+  let pool!: Pool; // assigned in before()
+
+  before(() => {
+    pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  });
+
+  after(async () => {
+    await pool.end();
+  });
+
+  it('applies UP migration — all tables created', async () => {
+    await pool.query(UP_SQL);
+
+    assert.ok(await tableExists(pool, 'users'), 'users table missing');
+    assert.ok(await tableExists(pool, 'groups'), 'groups table missing');
+    assert.ok(await tableExists(pool, 'members'), 'members table missing');
+    assert.ok(await tableExists(pool, 'transactions'), 'transactions table missing');
+  });
+
+  it('UP migration — expected indexes exist', async () => {
+    assert.ok(await indexExists(pool, 'idx_users_wallet_address'), 'idx_users_wallet_address');
+    assert.ok(await indexExists(pool, 'idx_groups_creator_id'), 'idx_groups_creator_id');
+    assert.ok(await indexExists(pool, 'idx_members_group_id'), 'idx_members_group_id');
+    assert.ok(await indexExists(pool, 'idx_members_member_address'), 'idx_members_member_address');
+    assert.ok(await indexExists(pool, 'idx_transactions_group_id'), 'idx_transactions_group_id');
+    assert.ok(
+      await indexExists(pool, 'idx_transactions_timestamp'),
+      'idx_transactions_timestamp'
+    );
+  });
+
+  it('applies DOWN migration — all tables dropped', async () => {
+    await pool.query(DOWN_SQL);
+
+    assert.ok(!(await tableExists(pool, 'transactions')), 'transactions still exists');
+    assert.ok(!(await tableExists(pool, 'members')), 'members still exists');
+    assert.ok(!(await tableExists(pool, 'groups')), 'groups still exists');
+    assert.ok(!(await tableExists(pool, 'users')), 'users still exists');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constraint tests
+// ---------------------------------------------------------------------------
+
+describe('Constraint tests', { skip: skipReason }, () => {
+  let pool!: Pool; // assigned in before()
+
+  before(async () => {
+    pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    await pool.query(DOWN_SQL);
+    await pool.query(UP_SQL);
+  });
+
+  after(async () => {
+    await pool.query(DOWN_SQL);
+    await pool.end();
+  });
+
+  it('rejects duplicate wallet_address on users', async () => {
+    await pool.query(
+      `INSERT INTO users (wallet_address, name)
+       VALUES ('GADDR1111111111111111111111111111111111111111111111111', 'Alice')`
+    );
+
+    await assert.rejects(
+      () =>
+        pool.query(
+          `INSERT INTO users (wallet_address, name)
+           VALUES ('GADDR1111111111111111111111111111111111111111111111111', 'Alice2')`
+        ),
+      /unique/i,
+      'Expected unique constraint violation on wallet_address'
+    );
+  });
+
+  it('rejects out-of-range percentage on members', async () => {
+    interface UserRow extends QueryResultRow {
+      id: string;
+    }
+    const userRes = await pool.query<UserRow>(
+      `INSERT INTO users (wallet_address, name)
+       VALUES ('GADDR2222222222222222222222222222222222222222222222222', 'Bob') RETURNING id`
+    );
+    const userId = userRes.rows[0]?.id as string;
+
+    interface GroupRow extends QueryResultRow {
+      id: string;
+    }
+    const groupRes = await pool.query<GroupRow>(
+      `INSERT INTO groups (creator_id, name, token) VALUES ($1, 'Test Group', 'XLM') RETURNING id`,
+      [userId]
+    );
+    const groupId = groupRes.rows[0]?.id as string;
+
+    await assert.rejects(
+      () =>
+        pool.query(
+          `INSERT INTO members (group_id, member_address, percentage) VALUES ($1, 'GADDR000', 0)`,
+          [groupId]
+        ),
+      /check/i,
+      'Expected check constraint violation for percentage = 0'
+    );
+
+    await assert.rejects(
+      () =>
+        pool.query(
+          `INSERT INTO members (group_id, member_address, percentage)
+           VALUES ($1, 'GADDR000', 101)`,
+          [groupId]
+        ),
+      /check/i,
+      'Expected check constraint violation for percentage = 101'
+    );
+  });
+
+  it('rejects duplicate tx_hash on transactions', async () => {
+    interface UserRow extends QueryResultRow {
+      id: string;
+    }
+    const userRes = await pool.query<UserRow>(
+      `INSERT INTO users (wallet_address, name)
+       VALUES ('GADDR3333333333333333333333333333333333333333333333333', 'Carol') RETURNING id`
+    );
+    const userId = userRes.rows[0]?.id as string;
+
+    interface GroupRow extends QueryResultRow {
+      id: string;
+    }
+    const groupRes = await pool.query<GroupRow>(
+      `INSERT INTO groups (creator_id, name, token) VALUES ($1, 'Tx Group', 'USDC') RETURNING id`,
+      [userId]
+    );
+    const groupId = groupRes.rows[0]?.id as string;
+
+    await pool.query(
+      `INSERT INTO transactions (group_id, amount, asset, timestamp, tx_hash)
+       VALUES ($1, 1000, 'XLM', NOW(), 'hash_abc123')`,
+      [groupId]
+    );
+
+    await assert.rejects(
+      () =>
+        pool.query(
+          `INSERT INTO transactions (group_id, amount, asset, timestamp, tx_hash)
+           VALUES ($1, 2000, 'XLM', NOW(), 'hash_abc123')`,
+          [groupId]
+        ),
+      /unique/i,
+      'Expected unique constraint violation on tx_hash'
+    );
+  });
+
+  it('rejects FK violation — group_id references non-existent group', async () => {
+    await assert.rejects(
+      () =>
+        pool.query(
+          `INSERT INTO members (group_id, member_address, percentage)
+           VALUES ('00000000-0000-0000-0000-000000000000', 'GADDR000', 50)`
+        ),
+      /foreign key/i,
+      'Expected foreign key constraint violation'
+    );
+  });
+});

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -1,0 +1,21 @@
+import { Pool } from 'pg';
+import type { QueryResult, QueryResultRow } from 'pg';
+
+/**
+ * Shared connection pool.  Connection string is read from DATABASE_URL;
+ * set that env var before importing this module in production.
+ */
+export const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+/**
+ * Execute a parameterised SQL statement against the shared pool.
+ * Generic T is the shape of each returned row.
+ */
+export async function query<T extends QueryResultRow = QueryResultRow>(
+  sql: string,
+  values?: unknown[]
+): Promise<QueryResult<T>> {
+  return pool.query<T>(sql, values);
+}

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,0 +1,66 @@
+/**
+ * CLI migration runner.
+ *
+ * Usage (after `pnpm build`):
+ *   node dist/db/migrate.js        # run all *_up.sql migrations
+ *   node dist/db/migrate.js down   # run all *_down.sql migrations
+ *
+ * Or via pnpm scripts:
+ *   pnpm --filter backend db:migrate
+ *   pnpm --filter backend db:migrate:down
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Pool } from 'pg';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// When compiled to dist/db/migrate.js the SQL files live two levels up at
+// src/db/migrations relative to the backend root.
+const migrationsDir = resolve(__dirname, '../../src/db/migrations');
+
+async function runMigrations(direction: 'up' | 'down'): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL environment variable is not set.');
+  }
+
+  const pool = new Pool({ connectionString });
+
+  try {
+    const suffix = `_${direction}.sql`;
+    let files = readdirSync(migrationsDir)
+      .filter((f) => f.endsWith(suffix))
+      .sort();
+
+    if (direction === 'down') {
+      files = files.reverse();
+    }
+
+    if (files.length === 0) {
+      console.log(`No ${direction} migration files found in ${migrationsDir}`);
+      return;
+    }
+
+    for (const file of files) {
+      const filePath = join(migrationsDir, file);
+      const sql = readFileSync(filePath, 'utf8');
+      console.log(`Running ${file} ...`);
+      await pool.query(sql);
+      console.log(`  ✓ ${file}`);
+    }
+
+    console.log(`\nAll ${direction} migrations completed successfully.`);
+  } finally {
+    await pool.end();
+  }
+}
+
+const direction: 'up' | 'down' = process.argv[2] === 'down' ? 'down' : 'up';
+
+runMigrations(direction).catch((err: unknown) => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});

--- a/backend/src/db/migrations/001_create_tables_down.sql
+++ b/backend/src/db/migrations/001_create_tables_down.sql
@@ -1,0 +1,7 @@
+-- Migration 001 DOWN: drop all tables created in 001_create_tables_up.sql
+-- Drop in reverse dependency order so FK constraints are satisfied.
+
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS members;
+DROP TABLE IF EXISTS groups;
+DROP TABLE IF EXISTS users;

--- a/backend/src/db/migrations/001_create_tables_up.sql
+++ b/backend/src/db/migrations/001_create_tables_up.sql
@@ -1,0 +1,51 @@
+-- Migration 001 UP: create users, groups, members, transactions tables
+-- Requires PostgreSQL 13+ for gen_random_uuid().
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS users (
+  id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_address VARCHAR(64)  UNIQUE NOT NULL,
+  name           VARCHAR(255) NOT NULL,
+  email          VARCHAR(255),
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_wallet_address ON users (wallet_address);
+
+CREATE TABLE IF NOT EXISTS groups (
+  id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id       UUID         NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  name             VARCHAR(255) NOT NULL,
+  token            VARCHAR(64)  NOT NULL,
+  onchain_group_id VARCHAR(128) UNIQUE,
+  created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_groups_creator_id ON groups (creator_id);
+
+CREATE TABLE IF NOT EXISTS members (
+  id             UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id       UUID          NOT NULL REFERENCES groups (id) ON DELETE CASCADE,
+  member_address VARCHAR(64)   NOT NULL,
+  percentage     NUMERIC(7, 4) NOT NULL CHECK (percentage > 0 AND percentage <= 100),
+  joined_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_members_group_id       ON members (group_id);
+CREATE INDEX IF NOT EXISTS idx_members_member_address ON members (member_address);
+
+CREATE TABLE IF NOT EXISTS transactions (
+  id         UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id   UUID          NOT NULL REFERENCES groups (id) ON DELETE CASCADE,
+  amount     NUMERIC(30,7) NOT NULL,
+  asset      VARCHAR(64)   NOT NULL,
+  timestamp  TIMESTAMPTZ   NOT NULL,
+  tx_hash    VARCHAR(128)  UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_transactions_group_id  ON transactions (group_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_timestamp ON transactions (timestamp);

--- a/backend/src/db/schema.sql
+++ b/backend/src/db/schema.sql
@@ -1,0 +1,68 @@
+-- =============================================================================
+-- PaymeshStellar — canonical off-chain PostgreSQL schema (reference)
+-- Run via migrations in src/db/migrations/.
+-- Requires PostgreSQL 13+ (gen_random_uuid() built-in).
+-- =============================================================================
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ---------------------------------------------------------------------------
+-- users
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS users (
+  id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_address VARCHAR(64)  UNIQUE NOT NULL,
+  name           VARCHAR(255) NOT NULL,
+  email          VARCHAR(255),
+  created_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- Explicit index on the most-filtered column (UNIQUE already creates one;
+-- kept here for documentation clarity).
+CREATE INDEX IF NOT EXISTS idx_users_wallet_address ON users (wallet_address);
+
+-- ---------------------------------------------------------------------------
+-- groups
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS groups (
+  id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id       UUID         NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  name             VARCHAR(255) NOT NULL,
+  token            VARCHAR(64)  NOT NULL,
+  onchain_group_id VARCHAR(128) UNIQUE,
+  created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_groups_creator_id ON groups (creator_id);
+
+-- ---------------------------------------------------------------------------
+-- members
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS members (
+  id             UUID           PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id       UUID           NOT NULL REFERENCES groups (id) ON DELETE CASCADE,
+  member_address VARCHAR(64)    NOT NULL,
+  percentage     NUMERIC(7, 4)  NOT NULL CHECK (percentage > 0 AND percentage <= 100),
+  joined_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_members_group_id       ON members (group_id);
+CREATE INDEX IF NOT EXISTS idx_members_member_address ON members (member_address);
+
+-- ---------------------------------------------------------------------------
+-- transactions
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS transactions (
+  id         UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id   UUID          NOT NULL REFERENCES groups (id) ON DELETE CASCADE,
+  amount     NUMERIC(30,7) NOT NULL,
+  asset      VARCHAR(64)   NOT NULL,
+  timestamp  TIMESTAMPTZ   NOT NULL,
+  tx_hash    VARCHAR(128)  UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_transactions_group_id  ON transactions (group_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_timestamp ON transactions (timestamp);


### PR DESCRIPTION
closes #75 


this PR  implemented the following changes:

- Add pg@^8.11.3 dependency and @types/pg@^8.11.6 dev dependency
- backend/src/db/schema.sql: canonical reference schema for all four tables
- backend/src/db/migrations/001_create_tables_up.sql: creates users, groups, members, transactions with UUIDs, FK ON DELETE CASCADE, UNIQUE constraints, CHECK (percentage > 0 AND percentage <= 100), and all documented indexes
- backend/src/db/migrations/001_create_tables_down.sql: drops tables in reverse dependency order
- backend/src/db/migrate.ts: CLI runner (node dist/db/migrate.js [down]); reads SQL files relative to the compiled dist directory, exposed via pnpm db:migrate / pnpm db:migrate:down scripts
- backend/src/db/index.ts: exports a shared pg.Pool and a generic query() helper for use by future service modules
- backend/src/db/__tests__/migrations.test.ts: migration smoke tests (up then assert tables/indexes then down then assert clean) plus constraint tests (duplicate wallet_address, duplicate tx_hash, out-of-range percentage, FK violation); all tests skip gracefully when DATABASE_URL is not set
- backend/.env.example: remove duplicate HORIZON_URL entry, add Docker quick-start comment for DATABASE_URL