### PR TITLE
feat(contract): skip zero-amount transfers in distribute

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -224,7 +224,11 @@ mod contract_impl {
 
             for (i, member) in details.members.iter().enumerate() {
                 let share = shares.get(i as u32).unwrap();
-                token_client.transfer(&from, &member.address, &share);
+                // Skip zero-value transfers: they move no tokens but still cost
+                // resource fees as a cross-contract call.
+                if share > 0 {
+                    token_client.transfer(&from, &member.address, &share);
+                }
             }
 
             events::distributed(&env, &id, &from, amount);


### PR DESCRIPTION
## Summary
- `distribute` now skips the `token.transfer` call for any member whose floor-divided share rounds to 0 (small percentages on small amounts), avoiding a cross-contract call that costs resource fees but moves no tokens.
- No behavior or API change: balances end up identical, rounding/dust handling (last member absorbs remainder) is untouched.

## Test plan
- [x] `cargo fmt --check` passes
- [ ] CI: `cargo build`, `cargo clippy`, `cargo test` (existing test suite, including the zero-share rounding cases like `test_distribute_rounding_minimal_amount_three_members`, already covers this path and should continue to pass unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)