### PR TITLE
feat(contract): contract upgradeability with versioned storage and resumable batched migration

### DIFF
--- a/contract/README.md
+++ b/contract/README.md
@@ -9,14 +9,20 @@ equals 50%, and `100` equals 1%.
 
 | Function | Signature | Authentication | Errors | Event |
 |---|---|---|---|---|
-| `create` | `create(id, name, creator, usage_count, payment_token) -> Result<(), AutoShareError>` | `creator` | `GroupAlreadyExists` | `("autoshare", "created")`, payload `(id, creator)` |
-| `update_members` | `update_members(id, caller, new_members) -> Result<(), AutoShareError>` | `caller`, who must be the group creator | `GroupNotFound`, `Unauthorized`, `EmptyMembers`, `DuplicateMember`, `InvalidPercentage` | `("autoshare", "members_updated")`, payload `(id, member_count)` |
+| `init` | `init(admin) -> Result<(), AutoShareError>` | None (one-time setup) | `AlreadyInitialized` | None |
+| `create` | `create(id, name, creator, usage_count, payment_token) -> Result<(), AutoShareError>` | `creator` | `MigrationRequired`, `GroupAlreadyExists` | `("autoshare", "created")`, payload `(id, creator)` |
+| `update_members` | `update_members(id, caller, new_members) -> Result<(), AutoShareError>` | `caller`, who must be the group creator | `MigrationRequired`, `GroupNotFound`, `Unauthorized`, `EmptyMembers`, `DuplicateMember`, `InvalidPercentage` | `("autoshare", "members_updated")`, payload `(id, member_count)` |
 | `get` | `get(id) -> Result<AutoShareDetails, AutoShareError>` | None | `GroupNotFound` | None |
 | `get_groups_by_creator` | `get_groups_by_creator(creator) -> Vec<AutoShareDetails>` | None | None | None |
-| `distribute` | `distribute(id, from, amount) -> Result<(), AutoShareError>` | `from` | `InvalidAmount`, `GroupNotFound`, `EmptyMembers`, `InsufficientBalance` | `("autoshare", "distributed")`, payload `(id, from, amount)` |
+| `distribute` | `distribute(id, from, amount) -> Result<(), AutoShareError>` | `from` | `MigrationRequired`, `InvalidAmount`, `GroupNotFound`, `EmptyMembers`, `InsufficientBalance` | `("autoshare", "distributed")`, payload `(id, from, amount)` |
 | `get_member_shares` | `get_member_shares(group_id, total_amount) -> Vec<i128>` | None | Panics if the group is missing or invalid | None |
 | `get_calculated_share` | `get_calculated_share(total, percentage) -> i128` | None | Panics on arithmetic overflow | None |
 | `get_total_percentage` | `get_total_percentage(group_id) -> u32` | None | Panics if the group is missing | None |
+| `upgrade` | `upgrade(caller, new_wasm_hash) -> Result<(), AutoShareError>` | `caller` (contract admin) | `Unauthorized`, `ContractNotPaused` | `("autoshare", "upgraded")`, payload `new_wasm_hash` |
+| `migrate` | `migrate(caller, limit) -> Result<MigrationProgress, AutoShareError>` | `caller` (contract admin) | `Unauthorized`, `NothingToMigrate` | `("autoshare", "migrated")`, payload `(migrated, remaining)` |
+| `schema_version` | `schema_version() -> u32` | None | None | None |
+| `pause` | `pause(caller) -> Result<(), AutoShareError>` | `caller` (contract admin) | `Unauthorized` | `("autoshare", "paused")`, payload `()` |
+| `unpause` | `unpause(caller) -> Result<(), AutoShareError>` | `caller` (contract admin) | `Unauthorized` | `("autoshare", "unpaused")`, payload `()` |
 
 `update_members` requires a non-empty list of unique member addresses. Every
 member percentage must be greater than zero, and the percentages must total
@@ -34,15 +40,79 @@ to the final member so all transfers sum exactly to the requested amount.
 - `src/interfaces/` defines the `AutoShareTrait` interface for compatible
   implementations and clients.
 
-The contract uses persistent Soroban storage with two key variants:
+### Storage Keys
 
+The contract partitions storage between **persistent** (group data and indexes) and **instance** (contract-level configuration and operational flags):
+
+#### Persistent Storage
 - `DataKey::Group(id)` stores one `AutoShareDetails` record by its 32-byte ID.
-- `DataKey::CreatorGroups(creator)` stores the ordered group IDs created by an
-  address, enabling `get_groups_by_creator`.
+- `DataKey::CreatorGroups(creator)` stores the ordered group IDs created by an address, enabling `get_groups_by_creator`.
+- `DataKey::AllGroups` maintains the global ordered list of all created group IDs (`Vec<BytesN<32>>`).
+
+#### Instance Storage
+- `DataKey::Admin` stores the contract administrator address.
+- `DataKey::SchemaVersion` stores the active `u32` schema version (read on nearly every call).
+- `DataKey::MigrationCursor` tracks the batch progress index into `AllGroups` during active migrations. Removed upon completion.
+- `DataKey::Paused` stores the `bool` maintenance flag.
 
 Public Rust items are protected by `#![deny(missing_docs)]`; adding an
 undocumented public API causes compilation and documentation generation to
 fail.
+
+## Upgrades and Migrations
+
+The contract implements contract upgradeability via Soroban's `update_current_contract_wasm` combined with instance-level schema versioning and resumable batched storage migration.
+
+### Migration Guardrails
+
+- **Mutating operations blocked during pending migrations**: While `schema_version() != CURRENT_SCHEMA_VERSION`, all mutating entrypoints (`create`, `update_members`, `distribute`) return `AutoShareError::MigrationRequired`.
+- **Read-only operations remain available**: Queries (`get`, `get_groups_by_creator`, `get_member_shares`, `get_total_percentage`) gracefully decode both legacy (v1) and current (v2) group formats.
+- **Admin-gated operations**: Only the contract administrator can call `pause`, `unpause`, `upgrade`, and `migrate`. Non-admin callers receive `AutoShareError::Unauthorized`.
+- **Upgrade safety gating**: `upgrade` strictly requires the contract to be paused (`Paused == true`). Calling `upgrade` while unpaused returns `AutoShareError::ContractNotPaused`.
+
+### Operator Runbook
+
+Follow these exact steps when upgrading a deployed contract:
+
+```bash
+# 1. Install the new contract WASM on-chain to obtain its 32-byte hash
+NEW_WASM_HASH=$(stellar contract install --wasm target/wasm32v1-none/release/autoshare.wasm --source <ADMIN> --network <NETWORK>)
+
+# 2. Pause the contract to prevent state mutations during the upgrade window
+stellar contract invoke --id <CONTRACT_ID> --source <ADMIN> --network <NETWORK> -- pause --caller <ADMIN>
+
+# 3. Upgrade contract WASM executable
+stellar contract invoke --id <CONTRACT_ID> --source <ADMIN> --network <NETWORK> -- upgrade --caller <ADMIN> --new_wasm_hash $NEW_WASM_HASH
+
+# 4. Run batched migration until all groups are upgraded (done == true)
+# Choose a limit (e.g. 50-100) appropriate for the network's transaction CPU/memory budget
+stellar contract invoke --id <CONTRACT_ID> --source <ADMIN> --network <NETWORK> -- migrate --caller <ADMIN> --limit 50
+
+# Repeat step 4 if remaining > 0 until done is true
+
+# 5. Verify the schema version
+stellar contract invoke --id <CONTRACT_ID> --source <ADMIN> --network <NETWORK> -- schema_version
+# Output: 2
+
+# 6. Unpause the contract to resume normal user operations
+stellar contract invoke --id <CONTRACT_ID> --source <ADMIN> --network <NETWORK> -- unpause --caller <ADMIN>
+```
+
+### Rollback Story: What is and is not Recoverable
+
+- **Recoverable**:
+  - If a migration is interrupted between batches, the contract remains in a consistent state. Group data is never corrupted or duplicated; unmigrated records remain readable via backward-compatible deserialization fallbacks. Calling `migrate` resumes exactly from the persisted cursor.
+  - If an upgrade fails before migration starts, the admin can re-install and point `upgrade` back to the previous WASM hash without data loss.
+- **Not Recoverable**:
+  - Once a migration batch writes records in the new schema format, rolling back the WASM to an older version that does not know about the new fields will cause decoding failures for migrated groups.
+  - Upgrading without pausing risks concurrent user transactions reading intermediate migration state or failing with `MigrationRequired`. Always pause before executing `upgrade`.
+
+### Global Group Index (`AllGroups`) Ceiling and Scaling
+
+The contract maintains `DataKey::AllGroups` (`Vec<BytesN<32>>`) to enable exhaustive iteration across all groups during migrations.
+- **Entry Size Ceiling**: Soroban limits a single persistent storage entry to 64 KB. With each group ID requiring 32 bytes (plus XDR vector overhead), `AllGroups` can store up to ~1,800–2,000 groups before reaching the entry limit.
+- **Write Cost**: Appending to `AllGroups` on each `create` call incurs a read-modify-write on the vector.
+- **Scaling Recommendation**: For deployments expecting more than 1,500 groups, transition the global index into paginated buckets (e.g., `DataKey::AllGroupsPage(u32)` containing fixed 500-group segments) or an on-chain linked-list / tree structure.
 
 ## Build, Test, and Documentation
 
@@ -92,3 +162,4 @@ stellar contract deploy \
 
 The deployment command prints the contract ID. Configure the selected source
 identity and network in Stellar CLI before deploying.
+

--- a/contract/src/base/auth.rs
+++ b/contract/src/base/auth.rs
@@ -1,7 +1,7 @@
 //! Authorization and validation helpers used by contract entrypoints.
 
 use crate::base::errors::AutoShareError;
-use crate::base::types::{AutoShareDetails, DataKey, GroupMember};
+use crate::base::types::{AutoShareDetails, AutoShareDetailsV1, DataKey, GroupMember};
 use soroban_sdk::{Address, BytesN, Env};
 
 /// Validates that a distribution amount is greater than zero.
@@ -38,7 +38,7 @@ pub fn validate_percentages(members: &soroban_sdk::Vec<GroupMember>) -> Result<(
     }
 }
 
-/// Loads an existing group from persistent storage.
+/// Loads an existing group from persistent storage, supporting both v2 and v1 formats.
 ///
 /// # Errors
 ///
@@ -47,10 +47,31 @@ pub fn validate_group_exists(
     env: &Env,
     id: &BytesN<32>,
 ) -> Result<AutoShareDetails, AutoShareError> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Group(id.clone()))
-        .ok_or(AutoShareError::GroupNotFound)
+    use soroban_sdk::{Map, TryFromVal, Val};
+
+    let key = DataKey::Group(id.clone());
+    if let Some(val) = env.storage().persistent().get::<DataKey, Val>(&key) {
+        if let Ok(map) = Map::<Val, Val>::try_from_val(env, &val) {
+            if map.len() == 6 {
+                if let Ok(v1) = AutoShareDetailsV1::try_from_val(env, &val) {
+                    return Ok(AutoShareDetails {
+                        id: v1.id,
+                        name: v1.name,
+                        creator: v1.creator,
+                        usage_count: v1.usage_count,
+                        payment_token: v1.payment_token,
+                        members: v1.members,
+                        version: 1,
+                    });
+                }
+            } else if map.len() == 7 {
+                if let Ok(details) = AutoShareDetails::try_from_val(env, &val) {
+                    return Ok(details);
+                }
+            }
+        }
+    }
+    Err(AutoShareError::GroupNotFound)
 }
 
 /// Finds a member by address.
@@ -146,21 +167,21 @@ pub fn require_group_member(
 
 /// Requires that `caller` is the contract admin.
 ///
-/// The admin address is stored under [`DataKey::Admin`]. This helper is
-/// intended for contract-level administrative operations introduced in #68.
+/// The admin address is stored under [`DataKey::Admin`].
 ///
 /// # Errors
 ///
-/// Returns [`AutoShareError::GroupNotFound`] when no admin has been set, or
-/// [`AutoShareError::Unauthorized`] when `caller` is not the admin.
+/// Returns [`AutoShareError::Unauthorized`] when no admin has been set or
+/// when `caller` is not the admin.
 pub fn require_admin(env: &Env, caller: &Address) -> Result<(), AutoShareError> {
     caller.require_auth();
 
     let admin: Address = env
         .storage()
-        .persistent()
+        .instance()
         .get(&DataKey::Admin)
-        .ok_or(AutoShareError::GroupNotFound)?;
+        .or_else(|| env.storage().persistent().get(&DataKey::Admin))
+        .ok_or(AutoShareError::Unauthorized)?;
 
     if admin == *caller {
         Ok(())
@@ -174,4 +195,46 @@ pub fn require_admin(env: &Env, caller: &Address) -> Result<(), AutoShareError> 
 /// Returns `true` if `address` appears in `details.members`, `false` otherwise.
 pub fn is_member(details: &AutoShareDetails, address: &Address) -> bool {
     details.members.iter().any(|m| m.address == *address)
+}
+
+/// Checks that the on-chain schema version matches [`crate::base::types::CURRENT_SCHEMA_VERSION`].
+///
+/// # Errors
+///
+/// Returns [`AutoShareError::MigrationRequired`] when the stored version is
+/// absent or does not equal the compiled constant.
+pub fn require_migration_current(env: &Env) -> Result<(), AutoShareError> {
+    use crate::base::types::CURRENT_SCHEMA_VERSION;
+
+    let stored: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::SchemaVersion)
+        .unwrap_or(0);
+
+    if stored == CURRENT_SCHEMA_VERSION {
+        Ok(())
+    } else {
+        Err(AutoShareError::MigrationRequired)
+    }
+}
+
+/// Checks that the contract is currently paused.
+///
+/// # Errors
+///
+/// Returns [`AutoShareError::ContractNotPaused`] when the contract is not
+/// paused or the `Paused` flag has never been set.
+pub fn require_paused(env: &Env) -> Result<(), AutoShareError> {
+    let paused: bool = env
+        .storage()
+        .instance()
+        .get(&DataKey::Paused)
+        .unwrap_or(false);
+
+    if paused {
+        Ok(())
+    } else {
+        Err(AutoShareError::ContractNotPaused)
+    }
 }

--- a/contract/src/base/errors.rs
+++ b/contract/src/base/errors.rs
@@ -29,6 +29,14 @@ pub enum AutoShareError {
     // Explicit variants requested by issue #54
     UnauthorizedAccess = 10,
     InvalidGroupId = 11,
+    /// The contract schema is outdated; call `migrate` before mutating state.
+    MigrationRequired = 12,
+    /// `migrate` was called but the schema is already at the current version.
+    NothingToMigrate = 13,
+    /// `upgrade` was called while the contract is not paused.
+    ContractNotPaused = 14,
+    /// The contract has already been initialized.
+    AlreadyInitialized = 15,
 }
 
 impl AutoShareError {
@@ -63,6 +71,18 @@ impl AutoShareError {
             }
             AutoShareError::InvalidGroupId => {
                 "Invalid group ID. The provided group ID does not exist or is malformed."
+            }
+            AutoShareError::MigrationRequired => {
+                "Migration required. Call migrate() before performing mutations."
+            }
+            AutoShareError::NothingToMigrate => {
+                "Nothing to migrate. The contract schema is already current."
+            }
+            AutoShareError::ContractNotPaused => {
+                "Contract not paused. Pause the contract before upgrading."
+            }
+            AutoShareError::AlreadyInitialized => {
+                "Already initialized. The contract has already been set up."
             }
         }
     }

--- a/contract/src/base/events.rs
+++ b/contract/src/base/events.rs
@@ -29,3 +29,30 @@ pub fn distributed(env: &Env, id: &BytesN<32>, from: &Address, amount: i128) {
         (id.clone(), from.clone(), amount),
     );
 }
+
+/// Publishes an `("autoshare", "upgraded")` event.
+///
+/// Topics are `"autoshare"` and `"upgraded"`. The payload is the new WASM hash.
+pub fn upgraded(env: &Env, new_wasm_hash: &BytesN<32>) {
+    env.events()
+        .publish(("autoshare", "upgraded"), new_wasm_hash.clone());
+}
+
+/// Publishes an `("autoshare", "migrated")` event.
+///
+/// Topics are `"autoshare"` and `"migrated"`. The payload is
+/// `(migrated_count, remaining_count)`.
+pub fn migrated(env: &Env, migrated_count: u32, remaining_count: u32) {
+    env.events()
+        .publish(("autoshare", "migrated"), (migrated_count, remaining_count));
+}
+
+/// Publishes an `("autoshare", "paused")` event.
+pub fn paused(env: &Env) {
+    env.events().publish(("autoshare", "paused"), ());
+}
+
+/// Publishes an `("autoshare", "unpaused")` event.
+pub fn unpaused(env: &Env) {
+    env.events().publish(("autoshare", "unpaused"), ());
+}

--- a/contract/src/base/types.rs
+++ b/contract/src/base/types.rs
@@ -3,6 +3,11 @@
 
 use soroban_sdk::{contracttype, Address, BytesN, String, Vec};
 
+/// Current schema version. Bumped on every storage-layout change.
+/// v1 = implicit pre-versioning layout (no `version` field on groups).
+/// v2 = adds `version: u32` to `AutoShareDetails`.
+pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+
 #[contracttype]
 #[derive(Debug, PartialEq, Clone)]
 /// A recipient and their configured share of a group distribution.
@@ -17,8 +22,11 @@ pub struct GroupMember {
 
 #[contracttype]
 #[derive(Debug, PartialEq, Clone)]
-/// Complete persisted configuration for an AutoShare group.
-pub struct AutoShareDetails {
+/// Legacy v1 group layout **without** a `version` field.
+///
+/// Used exclusively during migration to deserialize records written by the
+/// pre-versioning contract code.
+pub struct AutoShareDetailsV1 {
     /// Unique 32-byte group identifier.
     pub id: BytesN<32>,
     /// Human-readable group name.
@@ -34,7 +42,39 @@ pub struct AutoShareDetails {
 }
 
 #[contracttype]
-/// Keys used by the contract's persistent storage.
+#[derive(Debug, PartialEq, Clone)]
+/// Complete persisted configuration for an AutoShare group (v2+).
+pub struct AutoShareDetails {
+    /// Unique 32-byte group identifier.
+    pub id: BytesN<32>,
+    /// Human-readable group name.
+    pub name: String,
+    /// Address authorized to update the member list.
+    pub creator: Address,
+    /// Application-defined usage counter stored with the group.
+    pub usage_count: u32,
+    /// Token contract used for group distributions.
+    pub payment_token: Address,
+    /// Ordered recipients and their basis-point shares.
+    pub members: Vec<GroupMember>,
+    /// Schema version this record was written with.
+    pub version: u32,
+}
+
+#[contracttype]
+#[derive(Debug, PartialEq, Clone)]
+/// Result of a single `migrate` batch call.
+pub struct MigrationProgress {
+    /// Number of groups migrated in this batch.
+    pub migrated: u32,
+    /// Number of groups still awaiting migration.
+    pub remaining: u32,
+    /// `true` when all groups have been migrated.
+    pub done: bool,
+}
+
+#[contracttype]
+/// Keys used by the contract's persistent and instance storage.
 pub enum DataKey {
     /// Maps a group identifier to its [`AutoShareDetails`].
     Group(BytesN<32>),
@@ -42,4 +82,17 @@ pub enum DataKey {
     CreatorGroups(Address),
     /// Stores the contract admin address for administrative operations.
     Admin,
+    /// Current schema version (instance storage, read on nearly every call).
+    SchemaVersion,
+    /// Global ordered list of all group IDs (persistent storage).
+    ///
+    /// Each entry is a `BytesN<32>` (32 bytes). At ~2,000 groups the Vec
+    /// approaches Soroban's 64 KB persistent-entry limit. For deployments
+    /// expecting more groups, paginate into `AllGroupsPage(u32)` buckets.
+    AllGroups,
+    /// Cursor index into [`DataKey::AllGroups`] for resumable batched migration
+    /// (instance storage). Removed once migration completes.
+    MigrationCursor,
+    /// Whether the contract is paused (instance storage).
+    Paused,
 }

--- a/contract/src/interfaces/autoshare.rs
+++ b/contract/src/interfaces/autoshare.rs
@@ -3,10 +3,17 @@
 use soroban_sdk::{Address, BytesN, Env, String, Vec};
 
 use crate::base::errors::AutoShareError;
-use crate::base::types::{AutoShareDetails, GroupMember};
+use crate::base::types::{AutoShareDetails, GroupMember, MigrationProgress};
 
 /// Operations exposed by an AutoShare-compatible contract.
 pub trait AutoShareTrait {
+    /// One-time contract initialization.
+    ///
+    /// Sets the admin, stamps the schema version, and initializes the paused
+    /// flag to `false`. Returns [`AutoShareError::AlreadyInitialized`] on
+    /// repeated calls.
+    fn init(env: Env, admin: Address) -> Result<(), AutoShareError>;
+
     /// Creates an empty group and indexes it by creator.
     ///
     /// The creator must authorize the call. Returns
@@ -60,4 +67,26 @@ pub trait AutoShareTrait {
 
     /// Returns the sum of a group's member percentages in basis points.
     fn get_total_percentage(env: Env, group_id: BytesN<32>) -> u32;
+
+    /// Replaces the contract WASM with a new version.
+    ///
+    /// Admin-gated. The contract **must** be paused before upgrading. Emits
+    /// an `("autoshare", "upgraded")` event on success.
+    fn upgrade(env: Env, caller: Address, new_wasm_hash: BytesN<32>) -> Result<(), AutoShareError>;
+
+    /// Migrates up to `limit` groups from the old schema to the current one.
+    ///
+    /// Admin-gated. Returns [`MigrationProgress`] with the number of groups
+    /// migrated, remaining, and whether the job is done. When done, stamps the
+    /// schema version to [`crate::base::types::CURRENT_SCHEMA_VERSION`].
+    fn migrate(env: Env, caller: Address, limit: u32) -> Result<MigrationProgress, AutoShareError>;
+
+    /// Returns the contract's stored schema version (0 if never initialized).
+    fn schema_version(env: Env) -> u32;
+
+    /// Pauses the contract. Admin-gated.
+    fn pause(env: Env, caller: Address) -> Result<(), AutoShareError>;
+
+    /// Unpauses the contract. Admin-gated.
+    fn unpause(env: Env, caller: Address) -> Result<(), AutoShareError>;
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -16,12 +16,15 @@ pub mod interfaces;
 mod test;
 
 use base::auth::{
-    require_group_creator, validate_amount, validate_group_exists, validate_members_unique,
-    validate_percentages,
+    require_admin, require_group_creator, require_migration_current, require_paused,
+    validate_amount, validate_group_exists, validate_members_unique, validate_percentages,
 };
 use base::errors::AutoShareError;
 use base::events;
-use base::types::{AutoShareDetails, DataKey, GroupMember};
+use base::types::{
+    AutoShareDetails, AutoShareDetailsV1, DataKey, GroupMember, MigrationProgress,
+    CURRENT_SCHEMA_VERSION,
+};
 use interfaces::autoshare::AutoShareTrait;
 
 mod contract_impl {
@@ -35,10 +38,34 @@ mod contract_impl {
 
     #[contractimpl]
     impl AutoShareTrait for AutoShareContract {
+        /// Initializes the contract with an admin and stamps the initial schema version.
+        ///
+        /// # Parameters
+        ///
+        /// - `env`: Soroban execution environment.
+        /// - `admin`: Address granted administrator privileges.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`AutoShareError::AlreadyInitialized`] if already initialized.
+        fn init(env: Env, admin: Address) -> Result<(), AutoShareError> {
+            if env.storage().instance().has(&DataKey::Admin) {
+                return Err(AutoShareError::AlreadyInitialized);
+            }
+
+            env.storage().instance().set(&DataKey::Admin, &admin);
+            env.storage()
+                .instance()
+                .set(&DataKey::SchemaVersion, &CURRENT_SCHEMA_VERSION);
+            env.storage().instance().set(&DataKey::Paused, &false);
+
+            Ok(())
+        }
+
         /// Creates an empty AutoShare group.
         ///
-        /// The `creator` must authorize the call. The group is stored under `id`
-        /// and indexed under the creator's address.
+        /// The `creator` must authorize the call. The group is stored under `id`,
+        /// indexed under the creator's address, and added to the global group index.
         ///
         /// # Parameters
         ///
@@ -51,7 +78,8 @@ mod contract_impl {
         ///
         /// # Errors
         ///
-        /// Returns [`AutoShareError::GroupAlreadyExists`] when `id` is already stored.
+        /// Returns [`AutoShareError::MigrationRequired`] when an upgrade migration is pending,
+        /// or [`AutoShareError::GroupAlreadyExists`] when `id` is already stored.
         ///
         /// # Panics
         ///
@@ -64,6 +92,7 @@ mod contract_impl {
             usage_count: u32,
             payment_token: Address,
         ) -> Result<(), AutoShareError> {
+            require_migration_current(&env)?;
             creator.require_auth();
 
             if env.storage().persistent().has(&DataKey::Group(id.clone())) {
@@ -77,6 +106,7 @@ mod contract_impl {
                 usage_count,
                 payment_token,
                 members: Vec::new(&env),
+                version: CURRENT_SCHEMA_VERSION,
             };
 
             env.storage()
@@ -91,6 +121,16 @@ mod contract_impl {
                 .unwrap_or(Vec::new(&env));
             ids.push_back(id.clone());
             env.storage().persistent().set(&key, &ids);
+
+            // Maintain global group index for enumeration and migrations
+            let all_groups_key = DataKey::AllGroups;
+            let mut all_ids: Vec<BytesN<32>> = env
+                .storage()
+                .persistent()
+                .get(&all_groups_key)
+                .unwrap_or(Vec::new(&env));
+            all_ids.push_back(id.clone());
+            env.storage().persistent().set(&all_groups_key, &all_ids);
 
             events::group_created(&env, &id, &creator);
             Ok(())
@@ -111,11 +151,10 @@ mod contract_impl {
         ///
         /// # Errors
         ///
-        /// Returns [`AutoShareError::GroupNotFound`],
+        /// Returns [`AutoShareError::MigrationRequired`], [`AutoShareError::GroupNotFound`],
         /// [`AutoShareError::Unauthorized`], [`AutoShareError::EmptyMembers`],
         /// [`AutoShareError::DuplicateMember`], or
-        /// [`AutoShareError::InvalidPercentage`] when the corresponding validation
-        /// fails.
+        /// [`AutoShareError::InvalidPercentage`] when validation fails.
         ///
         /// # Panics
         ///
@@ -126,6 +165,8 @@ mod contract_impl {
             caller: Address,
             new_members: Vec<GroupMember>,
         ) -> Result<(), AutoShareError> {
+            require_migration_current(&env)?;
+
             let mut details = validate_group_exists(&env, &id)?;
 
             require_group_creator(&env, &details, &caller)?;
@@ -134,6 +175,7 @@ mod contract_impl {
 
             let count = new_members.len();
             details.members = new_members;
+            details.version = CURRENT_SCHEMA_VERSION;
             env.storage()
                 .persistent()
                 .set(&DataKey::Group(id.clone()), &details);
@@ -165,7 +207,7 @@ mod contract_impl {
 
             let mut result: Vec<AutoShareDetails> = Vec::new(&env);
             for id in ids.iter() {
-                if let Some(details) = env.storage().persistent().get(&DataKey::Group(id)) {
+                if let Ok(details) = validate_group_exists(&env, &id) {
                     result.push_back(details);
                 }
             }
@@ -187,7 +229,7 @@ mod contract_impl {
         ///
         /// # Errors
         ///
-        /// Returns [`AutoShareError::InvalidAmount`],
+        /// Returns [`AutoShareError::MigrationRequired`], [`AutoShareError::InvalidAmount`],
         /// [`AutoShareError::GroupNotFound`], [`AutoShareError::EmptyMembers`], or
         /// [`AutoShareError::InsufficientBalance`] when validation fails.
         ///
@@ -202,6 +244,7 @@ mod contract_impl {
             from: Address,
             amount: i128,
         ) -> Result<(), AutoShareError> {
+            require_migration_current(&env)?;
             from.require_auth();
 
             validate_amount(amount)?;
@@ -245,11 +288,7 @@ mod contract_impl {
         /// Panics when `group_id` is not stored or its persisted member percentages
         /// are invalid.
         fn get_member_shares(env: Env, group_id: BytesN<32>, total_amount: i128) -> Vec<i128> {
-            let details: AutoShareDetails = env
-                .storage()
-                .persistent()
-                .get(&DataKey::Group(group_id))
-                .expect("group not found");
+            let details = validate_group_exists(&env, &group_id).expect("group not found");
 
             base::utils::distribute_amounts(&env, total_amount, &details.members)
                 .expect("invalid group configuration")
@@ -274,17 +313,192 @@ mod contract_impl {
         ///
         /// Panics when `group_id` is not stored.
         fn get_total_percentage(env: Env, group_id: BytesN<32>) -> u32 {
-            let details: AutoShareDetails = env
-                .storage()
-                .persistent()
-                .get(&DataKey::Group(group_id))
-                .expect("group not found");
+            let details = validate_group_exists(&env, &group_id).expect("group not found");
 
             let mut sum: u32 = 0;
             for member in details.members.iter() {
                 sum = sum.saturating_add(member.percentage);
             }
             sum
+        }
+
+        /// Upgrades the contract WASM executable to a new hash.
+        ///
+        /// The caller must be the contract admin, and the contract must be paused.
+        ///
+        /// # Parameters
+        ///
+        /// - `env`: Soroban execution environment.
+        /// - `caller`: Admin address authorizing the upgrade.
+        /// - `new_wasm_hash`: 32-byte hash of the newly installed WASM.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`AutoShareError::Unauthorized`] if `caller` is not admin,
+        /// or [`AutoShareError::ContractNotPaused`] if the contract is active.
+        fn upgrade(
+            env: Env,
+            caller: Address,
+            new_wasm_hash: BytesN<32>,
+        ) -> Result<(), AutoShareError> {
+            require_admin(&env, &caller)?;
+            require_paused(&env)?;
+
+            env.deployer()
+                .update_current_contract_wasm(new_wasm_hash.clone());
+            events::upgraded(&env, &new_wasm_hash);
+            Ok(())
+        }
+
+        /// Performs batched migration of stored groups to [`CURRENT_SCHEMA_VERSION`].
+        ///
+        /// The caller must be the contract admin. Processes up to `limit` groups
+        /// per call using a persisted cursor.
+        ///
+        /// # Parameters
+        ///
+        /// - `env`: Soroban execution environment.
+        /// - `caller`: Admin address authorizing the migration.
+        /// - `limit`: Maximum number of groups to migrate in this transaction.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`AutoShareError::Unauthorized`] if `caller` is not admin,
+        /// or [`AutoShareError::NothingToMigrate`] if already at the current schema version.
+        fn migrate(
+            env: Env,
+            caller: Address,
+            limit: u32,
+        ) -> Result<MigrationProgress, AutoShareError> {
+            require_admin(&env, &caller)?;
+
+            let current_schema: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::SchemaVersion)
+                .unwrap_or(0);
+
+            if current_schema == CURRENT_SCHEMA_VERSION {
+                return Err(AutoShareError::NothingToMigrate);
+            }
+
+            let all_ids: Vec<BytesN<32>> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::AllGroups)
+                .unwrap_or(Vec::new(&env));
+
+            let total_groups = all_ids.len();
+            let cursor: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::MigrationCursor)
+                .unwrap_or(0);
+
+            if total_groups == 0 || cursor >= total_groups {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::SchemaVersion, &CURRENT_SCHEMA_VERSION);
+                env.storage().instance().remove(&DataKey::MigrationCursor);
+                events::migrated(&env, 0, 0);
+                return Ok(MigrationProgress {
+                    migrated: 0,
+                    remaining: 0,
+                    done: true,
+                });
+            }
+
+            let end = (cursor + limit).min(total_groups);
+            let mut count: u32 = 0;
+
+            use soroban_sdk::{Map, TryFromVal, Val};
+
+            for i in cursor..end {
+                let id = all_ids.get(i).unwrap();
+                let key = DataKey::Group(id.clone());
+
+                if let Some(val) = env.storage().persistent().get::<DataKey, Val>(&key) {
+                    if let Ok(map) = Map::<Val, Val>::try_from_val(&env, &val) {
+                        if map.len() == 6 {
+                            if let Ok(v1) = AutoShareDetailsV1::try_from_val(&env, &val) {
+                                let v2 = AutoShareDetails {
+                                    id: v1.id,
+                                    name: v1.name,
+                                    creator: v1.creator,
+                                    usage_count: v1.usage_count,
+                                    payment_token: v1.payment_token,
+                                    members: v1.members,
+                                    version: CURRENT_SCHEMA_VERSION,
+                                };
+                                env.storage().persistent().set(&key, &v2);
+                            }
+                        } else if map.len() == 7 {
+                            if let Ok(mut v2) = AutoShareDetails::try_from_val(&env, &val) {
+                                if v2.version != CURRENT_SCHEMA_VERSION {
+                                    v2.version = CURRENT_SCHEMA_VERSION;
+                                    env.storage().persistent().set(&key, &v2);
+                                }
+                            }
+                        }
+                    }
+                }
+                count += 1;
+            }
+
+            let new_cursor = end;
+            let remaining = total_groups - new_cursor;
+            let done = remaining == 0;
+
+            if done {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::SchemaVersion, &CURRENT_SCHEMA_VERSION);
+                env.storage().instance().remove(&DataKey::MigrationCursor);
+            } else {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::MigrationCursor, &new_cursor);
+            }
+
+            events::migrated(&env, count, remaining);
+
+            Ok(MigrationProgress {
+                migrated: count,
+                remaining,
+                done,
+            })
+        }
+
+        /// Returns the current schema version stamped in contract instance storage.
+        fn schema_version(env: Env) -> u32 {
+            env.storage()
+                .instance()
+                .get(&DataKey::SchemaVersion)
+                .unwrap_or(0)
+        }
+
+        /// Pauses the contract, allowing administrative maintenance and upgrades.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`AutoShareError::Unauthorized`] if `caller` is not admin.
+        fn pause(env: Env, caller: Address) -> Result<(), AutoShareError> {
+            require_admin(&env, &caller)?;
+            env.storage().instance().set(&DataKey::Paused, &true);
+            events::paused(&env);
+            Ok(())
+        }
+
+        /// Unpauses the contract, resuming normal operation.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`AutoShareError::Unauthorized`] if `caller` is not admin.
+        fn unpause(env: Env, caller: Address) -> Result<(), AutoShareError> {
+            require_admin(&env, &caller)?;
+            env.storage().instance().set(&DataKey::Paused, &false);
+            events::unpaused(&env);
+            Ok(())
         }
     }
 }

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -13,6 +13,8 @@ fn setup_env() -> (Env, AutoShareContractClient<'static>, Address, Address) {
     env.mock_all_auths();
     let contract_id = env.register(AutoShareContract, ());
     let client = AutoShareContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
     let creator = Address::generate(&env);
     let token = Address::generate(&env);
     (env, client, creator, token)
@@ -26,6 +28,8 @@ fn setup_token_env() -> (Env, AutoShareContractClient<'static>, Address, Address
     let token_address = token_id.address();
     let contract_id = env.register(AutoShareContract, ());
     let client = AutoShareContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
     let creator = Address::generate(&env);
     (env, client, creator, token_address)
 }
@@ -299,13 +303,7 @@ fn test_distribute_group_not_found() {
 
 #[test]
 fn test_distribute_insufficient_balance() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token_address = token_id.address();
-    let contract_id = env.register(AutoShareContract, ());
-    let client = AutoShareContractClient::new(&env, &contract_id);
-    let creator = Address::generate(&env);
+    let (env, client, creator, token_address) = setup_token_env();
 
     // Mint only 50, but try to distribute 1000
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
@@ -357,14 +355,7 @@ fn test_distribute_single_member_odd_amount() {
 
 #[test]
 fn test_distribute_two_members_60_40() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token_address = token_id.address();
-    let contract_id = env.register(AutoShareContract, ());
-    let client = AutoShareContractClient::new(&env, &contract_id);
-    let creator = Address::generate(&env);
+    let (env, client, creator, token_address) = setup_token_env();
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
     token_admin.mint(&creator, &1_000);
 
@@ -476,14 +467,7 @@ fn test_distribute_five_members_sum_equals_total() {
 
 #[test]
 fn test_distribute_rounding_three_way_33_33_34() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let token_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
-    let token_address = token_id.address();
-    let contract_id = env.register(AutoShareContract, ());
-    let client = AutoShareContractClient::new(&env, &contract_id);
-    let creator = Address::generate(&env);
+    let (env, client, creator, token_address) = setup_token_env();
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
     token_admin.mint(&creator, &100);
 
@@ -780,4 +764,390 @@ fn test_distribute_emits_distributed_event() {
         has_distributed,
         "expected distributed event was not emitted"
     );
+}
+
+// ── upgrade & migration tests ────────────────────────────────────────────────
+
+#[test]
+fn test_init_stamps_schema_version_and_sets_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AutoShareContract, ());
+    let client = AutoShareContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    assert_eq!(client.schema_version(), 0);
+    client.init(&admin);
+    assert_eq!(client.schema_version(), CURRENT_SCHEMA_VERSION);
+
+    // Repeated init must fail
+    let admin2 = Address::generate(&env);
+    let err = client.try_init(&admin2);
+    assert_eq!(err, Err(Ok(AutoShareError::AlreadyInitialized)));
+}
+
+#[test]
+fn test_full_upgrade_lifecycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AutoShareContract, ());
+    let client = AutoShareContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    // Seed v1 layout in storage directly (simulating a deployed v1 contract with pre-existing data)
+    let id1 = BytesN::from_array(&env, &[101u8; 32]);
+    let id2 = BytesN::from_array(&env, &[102u8; 32]);
+    let member_addr = Address::generate(&env);
+
+    let mut members1 = Vec::new(&env);
+    members1.push_back(GroupMember {
+        address: member_addr.clone(),
+        name: String::from_str(&env, "Alice"),
+        percentage: 10000,
+    });
+
+    let v1_group1 = AutoShareDetailsV1 {
+        id: id1.clone(),
+        name: String::from_str(&env, "V1 Alpha"),
+        creator: creator.clone(),
+        usage_count: 5,
+        payment_token: token.clone(),
+        members: members1.clone(),
+    };
+
+    let v1_group2 = AutoShareDetailsV1 {
+        id: id2.clone(),
+        name: String::from_str(&env, "V1 Beta"),
+        creator: creator.clone(),
+        usage_count: 10,
+        payment_token: token.clone(),
+        members: Vec::new(&env),
+    };
+
+    env.as_contract(&contract_id, || {
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::SchemaVersion, &1u32);
+        env.storage().instance().set(&DataKey::Paused, &false);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Group(id1.clone()), &v1_group1);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Group(id2.clone()), &v1_group2);
+
+        let mut creator_groups = Vec::new(&env);
+        creator_groups.push_back(id1.clone());
+        creator_groups.push_back(id2.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::CreatorGroups(creator.clone()), &creator_groups);
+
+        let mut all_groups = Vec::new(&env);
+        all_groups.push_back(id1.clone());
+        all_groups.push_back(id2.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllGroups, &all_groups);
+    });
+
+    assert_eq!(client.schema_version(), 1);
+
+    // 1. Assert mutating calls fail with MigrationRequired while schema_version != CURRENT_SCHEMA_VERSION
+    let new_id = BytesN::from_array(&env, &[103u8; 32]);
+    let err_create = client.try_create(
+        &new_id,
+        &String::from_str(&env, "New Group"),
+        &creator,
+        &1,
+        &token,
+    );
+    assert_eq!(err_create, Err(Ok(AutoShareError::MigrationRequired)));
+
+    let err_update = client.try_update_members(&id1, &creator, &members1);
+    assert_eq!(err_update, Err(Ok(AutoShareError::MigrationRequired)));
+
+    let err_distribute = client.try_distribute(&id1, &creator, &100);
+    assert_eq!(err_distribute, Err(Ok(AutoShareError::MigrationRequired)));
+
+    // 2. Assert read operations remain available and correctly return v1 group data
+    let group1 = client.get(&id1);
+    assert_eq!(group1.id, id1);
+    assert_eq!(group1.name, String::from_str(&env, "V1 Alpha"));
+    assert_eq!(group1.creator, creator);
+    assert_eq!(group1.usage_count, 5);
+    assert_eq!(group1.version, 1);
+    assert_eq!(group1.members.len(), 1);
+
+    let creator_groups = client.get_groups_by_creator(&creator);
+    assert_eq!(creator_groups.len(), 2);
+
+    let shares = client.get_member_shares(&id1, &1000);
+    assert_eq!(shares.get(0).unwrap(), 1000);
+
+    // 3. Pause and run migration
+    client.pause(&admin);
+    let progress = client.migrate(&admin, &10);
+    assert_eq!(progress.migrated, 2);
+    assert_eq!(progress.remaining, 0);
+    assert!(progress.done);
+
+    assert_eq!(client.schema_version(), CURRENT_SCHEMA_VERSION);
+    client.unpause(&admin);
+
+    // 4. Assert mutations now succeed
+    let res_create = client.try_create(
+        &new_id,
+        &String::from_str(&env, "New Group"),
+        &creator,
+        &1,
+        &token,
+    );
+    assert!(res_create.is_ok());
+
+    // 5. Assert every group's data survived field-for-field with upgraded schema version
+    let upgraded_g1 = client.get(&id1);
+    assert_eq!(upgraded_g1.id, v1_group1.id);
+    assert_eq!(upgraded_g1.name, v1_group1.name);
+    assert_eq!(upgraded_g1.creator, v1_group1.creator);
+    assert_eq!(upgraded_g1.usage_count, v1_group1.usage_count);
+    assert_eq!(upgraded_g1.payment_token, v1_group1.payment_token);
+    assert_eq!(upgraded_g1.members, v1_group1.members);
+    assert_eq!(upgraded_g1.version, CURRENT_SCHEMA_VERSION);
+
+    let upgraded_g2 = client.get(&id2);
+    assert_eq!(upgraded_g2.id, v1_group2.id);
+    assert_eq!(upgraded_g2.name, v1_group2.name);
+    assert_eq!(upgraded_g2.creator, v1_group2.creator);
+    assert_eq!(upgraded_g2.usage_count, v1_group2.usage_count);
+    assert_eq!(upgraded_g2.payment_token, v1_group2.payment_token);
+    assert_eq!(upgraded_g2.members, v1_group2.members);
+    assert_eq!(upgraded_g2.version, CURRENT_SCHEMA_VERSION);
+}
+
+#[test]
+fn test_batch_resumption_7_groups_limit_3() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AutoShareContract, ());
+    let client = AutoShareContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    // Setup 7 groups in V1 layout
+    let mut all_ids = Vec::new(&env);
+    env.as_contract(&contract_id, || {
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::SchemaVersion, &1u32);
+        env.storage().instance().set(&DataKey::Paused, &false);
+
+        for i in 1..=7u8 {
+            let id = BytesN::from_array(&env, &[i; 32]);
+            all_ids.push_back(id.clone());
+
+            let v1 = AutoShareDetailsV1 {
+                id: id.clone(),
+                name: String::from_str(&env, "Group"),
+                creator: creator.clone(),
+                usage_count: i as u32,
+                payment_token: token.clone(),
+                members: Vec::new(&env),
+            };
+            env.storage().persistent().set(&DataKey::Group(id), &v1);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllGroups, &all_ids);
+    });
+
+    // Call 1: limit 3 -> migrates 3, 4 remaining
+    let p1 = client.migrate(&admin, &3);
+    assert_eq!(p1.migrated, 3);
+    assert_eq!(p1.remaining, 4);
+    assert!(!p1.done);
+    assert_eq!(client.schema_version(), 1);
+
+    // Call 2: limit 3 -> migrates 3, 1 remaining
+    let p2 = client.migrate(&admin, &3);
+    assert_eq!(p2.migrated, 3);
+    assert_eq!(p2.remaining, 1);
+    assert!(!p2.done);
+    assert_eq!(client.schema_version(), 1);
+
+    // Call 3: limit 3 -> migrates 1, 0 remaining, done!
+    let p3 = client.migrate(&admin, &3);
+    assert_eq!(p3.migrated, 1);
+    assert_eq!(p3.remaining, 0);
+    assert!(p3.done);
+    assert_eq!(client.schema_version(), CURRENT_SCHEMA_VERSION);
+
+    // Exactly 3 calls completed migration. 4th call returns NothingToMigrate.
+    let err = client.try_migrate(&admin, &3);
+    assert_eq!(err, Err(Ok(AutoShareError::NothingToMigrate)));
+
+    // Verify all 7 groups are migrated to CURRENT_SCHEMA_VERSION
+    for i in 1..=7u8 {
+        let id = BytesN::from_array(&env, &[i; 32]);
+        let g = client.get(&id);
+        assert_eq!(g.version, CURRENT_SCHEMA_VERSION);
+        assert_eq!(g.usage_count, i as u32);
+    }
+}
+
+#[test]
+fn test_interrupted_migration_consistent_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AutoShareContract, ());
+    let client = AutoShareContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let mut all_ids = Vec::new(&env);
+    env.as_contract(&contract_id, || {
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::SchemaVersion, &1u32);
+        env.storage().instance().set(&DataKey::Paused, &false);
+
+        for i in 1..=5u8 {
+            let id = BytesN::from_array(&env, &[i; 32]);
+            all_ids.push_back(id.clone());
+
+            let v1 = AutoShareDetailsV1 {
+                id: id.clone(),
+                name: String::from_str(&env, "Group"),
+                creator: creator.clone(),
+                usage_count: i as u32,
+                payment_token: token.clone(),
+                members: Vec::new(&env),
+            };
+            env.storage().persistent().set(&DataKey::Group(id), &v1);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllGroups, &all_ids);
+    });
+
+    // Run batch 1 (2 groups) and interrupt (don't call migrate again)
+    let p1 = client.migrate(&admin, &2);
+    assert_eq!(p1.migrated, 2);
+    assert_eq!(p1.remaining, 3);
+    assert!(!p1.done);
+
+    // Verify readable state for all 5 groups
+    for i in 1..=5u8 {
+        let id = BytesN::from_array(&env, &[i; 32]);
+        let g = client.get(&id);
+        assert_eq!(g.usage_count, i as u32);
+        if i <= 2 {
+            assert_eq!(g.version, CURRENT_SCHEMA_VERSION);
+        } else {
+            assert_eq!(g.version, 1);
+        }
+    }
+}
+
+#[test]
+fn test_non_admin_upgrade_unauthorized() {
+    let (env, client, _creator, _token) = setup_env();
+    let stranger = Address::generate(&env);
+    let fake_wasm_hash = BytesN::from_array(&env, &[99u8; 32]);
+
+    let err = client.try_upgrade(&stranger, &fake_wasm_hash);
+    assert_eq!(err, Err(Ok(AutoShareError::Unauthorized)));
+}
+
+#[test]
+fn test_non_admin_migrate_unauthorized() {
+    let (env, client, _creator, _token) = setup_env();
+    let stranger = Address::generate(&env);
+
+    let err = client.try_migrate(&stranger, &5);
+    assert_eq!(err, Err(Ok(AutoShareError::Unauthorized)));
+}
+
+#[test]
+fn test_upgrade_while_unpaused_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AutoShareContract, ());
+    let client = AutoShareContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let fake_wasm_hash = BytesN::from_array(&env, &[88u8; 32]);
+
+    // Contract is not paused -> upgrade returns ContractNotPaused
+    let err = client.try_upgrade(&admin, &fake_wasm_hash);
+    assert_eq!(err, Err(Ok(AutoShareError::ContractNotPaused)));
+
+    // Pause contract -> upgrade proceeds past the pause check
+    client.pause(&admin);
+    // Note: upgrade with a non-existent wasm hash in test env will fail at deployer level or succeed if mock
+    let res = client.try_upgrade(&admin, &fake_wasm_hash);
+    // In soroban testutils with mock_all_auths, deployer update will succeed or throw host error for invalid wasm,
+    // but the contract level validation (auth and pause) succeeded.
+    assert_ne!(res, Err(Ok(AutoShareError::ContractNotPaused)));
+    assert_ne!(res, Err(Ok(AutoShareError::Unauthorized)));
+}
+
+#[test]
+fn test_migrate_when_current_returns_nothing_to_migrate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AutoShareContract, ());
+    let client = AutoShareContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    assert_eq!(client.schema_version(), CURRENT_SCHEMA_VERSION);
+    let err = client.try_migrate(&admin, &10);
+    assert_eq!(err, Err(Ok(AutoShareError::NothingToMigrate)));
+}
+
+#[test]
+fn test_pause_unpause_admin_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AutoShareContract, ());
+    let client = AutoShareContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    client.init(&admin);
+
+    // Non-admin cannot pause or unpause
+    assert_eq!(
+        client.try_pause(&stranger),
+        Err(Ok(AutoShareError::Unauthorized))
+    );
+    assert_eq!(
+        client.try_unpause(&stranger),
+        Err(Ok(AutoShareError::Unauthorized))
+    );
+
+    // Admin can pause and unpause
+    assert!(client.try_pause(&admin).is_ok());
+    assert!(client.try_unpause(&admin).is_ok());
+}
+
+#[test]
+fn test_all_groups_global_index_maintained_on_create() {
+    let (env, client, creator, token) = setup_env();
+
+    let id1 = BytesN::from_array(&env, &[111u8; 32]);
+    let id2 = BytesN::from_array(&env, &[112u8; 32]);
+
+    client.create(&id1, &String::from_str(&env, "G1"), &creator, &1, &token);
+    client.create(&id2, &String::from_str(&env, "G2"), &creator, &2, &token);
+
+    let g1 = client.get(&id1);
+    assert_eq!(g1.version, CURRENT_SCHEMA_VERSION);
+    let g2 = client.get(&id2);
+    assert_eq!(g2.version, CURRENT_SCHEMA_VERSION);
 }

--- a/contract/test_snapshots/test/test_create_and_get.1.json
+++ b/contract/test_snapshots/test/test_create_and_get.1.json
@@ -1,13 +1,14 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0
   },
   "auth": [
     [],
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -21,13 +22,13 @@
                   "string": "Payroll Team A"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 3
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -55,10 +56,53 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "AllGroups"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllGroups"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CreatorGroups"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -78,7 +122,7 @@
                       "symbol": "CreatorGroups"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -139,7 +183,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -171,7 +215,7 @@
                         "symbol": "payment_token"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -180,6 +224,14 @@
                       },
                       "val": {
                         "u32": 3
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "version"
+                      },
+                      "val": {
+                        "u32": 2
                       }
                     }
                   ]
@@ -213,7 +265,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -226,7 +315,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -241,7 +330,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462

--- a/contract/test_snapshots/test/test_distribute_group_not_found.1.json
+++ b/contract/test_snapshots/test/test_distribute_group_not_found.1.json
@@ -1,9 +1,10 @@
 {
   "generators": {
-    "address": 2,
+    "address": 4,
     "nonce": 0
   },
   "auth": [
+    [],
     [],
     []
   ],
@@ -20,7 +21,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -31,7 +32,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": "ledger_key_contract_instance",
                 "durability": "persistent",
                 "val": {
@@ -39,7 +40,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contract/test_snapshots/test/test_distribute_insufficient_balance.1.json
+++ b/contract/test_snapshots/test/test_distribute_insufficient_balance.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 6,
+    "address": 7,
     "nonce": 0
   },
   "auth": [
@@ -24,6 +24,7 @@
       ]
     ],
     [],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
@@ -34,12 +35,12 @@
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 10
+                    "lo": 50
                   }
                 }
               ]
@@ -51,7 +52,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
         {
           "function": {
             "contract_fn": {
@@ -59,13 +60,13 @@
               "function_name": "create",
               "args": [
                 {
-                  "bytes": "1919191919191919191919191919191919191919191919191919191919191919"
+                  "bytes": "1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e"
                 },
                 {
                   "string": "Test Group"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
                   "u32": 1
@@ -82,7 +83,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
         {
           "function": {
             "contract_fn": {
@@ -90,41 +91,13 @@
               "function_name": "update_members",
               "args": [
                 {
-                  "bytes": "1919191919191919191919191919191919191919191919191919191919191919"
+                  "bytes": "1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
                   "vec": [
-                    {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "address"
-                          },
-                          "val": {
-                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "name"
-                          },
-                          "val": {
-                            "string": "Member"
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "percentage"
-                          },
-                          "val": {
-                            "u32": 6000
-                          }
-                        }
-                      ]
-                    },
                     {
                       "map": [
                         {
@@ -148,7 +121,35 @@
                             "symbol": "percentage"
                           },
                           "val": {
-                            "u32": 4000
+                            "u32": 5000
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "address"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "name"
+                          },
+                          "val": {
+                            "string": "Member"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "percentage"
+                          },
+                          "val": {
+                            "u32": 5000
                           }
                         }
                       ]
@@ -162,8 +163,6 @@
         }
       ]
     ],
-    [],
-    [],
     []
   ],
   "ledger": {
@@ -277,10 +276,53 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "AllGroups"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllGroups"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CreatorGroups"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 }
               ]
             },
@@ -300,7 +342,7 @@
                       "symbol": "CreatorGroups"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                     }
                   ]
                 },
@@ -308,7 +350,7 @@
                 "val": {
                   "vec": [
                     {
-                      "bytes": "1919191919191919191919191919191919191919191919191919191919191919"
+                      "bytes": "1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e"
                     }
                   ]
                 }
@@ -329,7 +371,7 @@
                   "symbol": "Group"
                 },
                 {
-                  "bytes": "1919191919191919191919191919191919191919191919191919191919191919"
+                  "bytes": "1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e"
                 }
               ]
             },
@@ -349,7 +391,7 @@
                       "symbol": "Group"
                     },
                     {
-                      "bytes": "1919191919191919191919191919191919191919191919191919191919191919"
+                      "bytes": "1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e"
                     }
                   ]
                 },
@@ -361,7 +403,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                       }
                     },
                     {
@@ -369,7 +411,7 @@
                         "symbol": "id"
                       },
                       "val": {
-                        "bytes": "1919191919191919191919191919191919191919191919191919191919191919"
+                        "bytes": "1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e"
                       }
                     },
                     {
@@ -378,34 +420,6 @@
                       },
                       "val": {
                         "vec": [
-                          {
-                            "map": [
-                              {
-                                "key": {
-                                  "symbol": "address"
-                                },
-                                "val": {
-                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                                }
-                              },
-                              {
-                                "key": {
-                                  "symbol": "name"
-                                },
-                                "val": {
-                                  "string": "Member"
-                                }
-                              },
-                              {
-                                "key": {
-                                  "symbol": "percentage"
-                                },
-                                "val": {
-                                  "u32": 6000
-                                }
-                              }
-                            ]
-                          },
                           {
                             "map": [
                               {
@@ -429,7 +443,35 @@
                                   "symbol": "percentage"
                                 },
                                 "val": {
-                                  "u32": 4000
+                                  "u32": 5000
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "address"
+                                },
+                                "val": {
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "name"
+                                },
+                                "val": {
+                                  "string": "Member"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "percentage"
+                                },
+                                "val": {
+                                  "u32": 5000
                                 }
                               }
                             ]
@@ -459,6 +501,14 @@
                       },
                       "val": {
                         "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "version"
+                      },
+                      "val": {
+                        "u32": 2
                       }
                     }
                   ]
@@ -492,7 +542,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -505,7 +592,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 1033654523790656264
@@ -520,7 +607,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 1033654523790656264
@@ -538,7 +625,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 4837995959683129791
@@ -553,7 +640,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 4837995959683129791
@@ -578,7 +665,7 @@
                   "symbol": "Balance"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 }
               ]
             },
@@ -598,7 +685,7 @@
                       "symbol": "Balance"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                     }
                   ]
                 },
@@ -612,7 +699,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 10
+                          "lo": 50
                         }
                       }
                     },

--- a/contract/test_snapshots/test/test_distribute_negative_amount.1.json
+++ b/contract/test_snapshots/test/test_distribute_negative_amount.1.json
@@ -4,33 +4,15 @@
     "nonce": 0
   },
   "auth": [
-    [
-      [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
-              "function_name": "set_admin",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
+    [],
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "function_name": "create",
               "args": [
                 {
@@ -40,13 +22,13 @@
                   "string": "G"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
                 },
                 {
-                  "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -69,76 +51,12 @@
     "ledger_entries": [
       [
         {
-          "account": {
-            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "account": {
-                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
-                "balance": 0,
-                "seq_num": 0,
-                "num_sub_entries": 0,
-                "inflation_dest": null,
-                "flags": 0,
-                "home_domain": "",
-                "thresholds": "01010101",
-                "signers": [],
-                "ext": "v0"
-              }
-            },
-            "ext": "v0"
-          },
-          null
-        ]
-      ],
-      [
-        {
           "contract_data": {
-            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 801925984706572462
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
               "vec": [
                 {
-                  "symbol": "CreatorGroups"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "symbol": "AllGroups"
                 }
               ]
             },
@@ -151,14 +69,11 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
                   "vec": [
                     {
-                      "symbol": "CreatorGroups"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "symbol": "AllGroups"
                     }
                   ]
                 },
@@ -180,7 +95,56 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CreatorGroups"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CreatorGroups"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "1515151515151515151515151515151515151515151515151515151515151515"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
               "vec": [
                 {
@@ -200,7 +164,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
                   "vec": [
                     {
@@ -219,7 +183,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -251,7 +215,7 @@
                         "symbol": "payment_token"
                       },
                       "val": {
-                        "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -260,6 +224,14 @@
                       },
                       "val": {
                         "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "version"
+                      },
+                      "val": {
+                        "u32": 2
                       }
                     }
                   ]
@@ -274,7 +246,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -285,7 +257,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": "ledger_key_contract_instance",
                 "durability": "persistent",
                 "val": {
@@ -293,7 +265,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -306,10 +315,10 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 5541220902715666415
+                "nonce": 801925984706572462
               }
             },
             "durability": "temporary"
@@ -321,10 +330,10 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
+                    "nonce": 801925984706572462
                   }
                 },
                 "durability": "temporary",
@@ -334,118 +343,6 @@
             "ext": "v0"
           },
           6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
-            "key": "ledger_key_contract_instance",
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
-                "key": "ledger_key_contract_instance",
-                "durability": "persistent",
-                "val": {
-                  "contract_instance": {
-                    "executable": "stellar_asset",
-                    "storage": [
-                      {
-                        "key": {
-                          "symbol": "METADATA"
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "decimal"
-                              },
-                              "val": {
-                                "u32": 7
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "name"
-                              },
-                              "val": {
-                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "symbol"
-                              },
-                              "val": {
-                                "string": "aaa"
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "Admin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "AssetInfo"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "symbol": "AlphaNum4"
-                            },
-                            {
-                              "map": [
-                                {
-                                  "key": {
-                                    "symbol": "asset_code"
-                                  },
-                                  "val": {
-                                    "string": "aaa\\0"
-                                  }
-                                },
-                                {
-                                  "key": {
-                                    "symbol": "issuer"
-                                  },
-                                  "val": {
-                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000002"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          120960
         ]
       ],
       [

--- a/contract/test_snapshots/test/test_distribute_zero_amount.1.json
+++ b/contract/test_snapshots/test/test_distribute_zero_amount.1.json
@@ -4,33 +4,15 @@
     "nonce": 0
   },
   "auth": [
-    [
-      [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
-              "function_name": "set_admin",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
+    [],
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "function_name": "create",
               "args": [
                 {
@@ -40,13 +22,13 @@
                   "string": "G"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
                 },
                 {
-                  "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -69,76 +51,12 @@
     "ledger_entries": [
       [
         {
-          "account": {
-            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "account": {
-                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
-                "balance": 0,
-                "seq_num": 0,
-                "num_sub_entries": 0,
-                "inflation_dest": null,
-                "flags": 0,
-                "home_domain": "",
-                "thresholds": "01010101",
-                "signers": [],
-                "ext": "v0"
-              }
-            },
-            "ext": "v0"
-          },
-          null
-        ]
-      ],
-      [
-        {
           "contract_data": {
-            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 801925984706572462
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
               "vec": [
                 {
-                  "symbol": "CreatorGroups"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "symbol": "AllGroups"
                 }
               ]
             },
@@ -151,14 +69,11 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
                   "vec": [
                     {
-                      "symbol": "CreatorGroups"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "symbol": "AllGroups"
                     }
                   ]
                 },
@@ -180,7 +95,56 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "CreatorGroups"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "CreatorGroups"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "1414141414141414141414141414141414141414141414141414141414141414"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
               "vec": [
                 {
@@ -200,7 +164,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
                   "vec": [
                     {
@@ -219,7 +183,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -251,7 +215,7 @@
                         "symbol": "payment_token"
                       },
                       "val": {
-                        "address": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -260,6 +224,14 @@
                       },
                       "val": {
                         "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "version"
+                      },
+                      "val": {
+                        "u32": 2
                       }
                     }
                   ]
@@ -274,7 +246,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -285,7 +257,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": "ledger_key_contract_instance",
                 "durability": "persistent",
                 "val": {
@@ -293,7 +265,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -306,10 +315,10 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 5541220902715666415
+                "nonce": 801925984706572462
               }
             },
             "durability": "temporary"
@@ -321,10 +330,10 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
+                    "nonce": 801925984706572462
                   }
                 },
                 "durability": "temporary",
@@ -334,118 +343,6 @@
             "ext": "v0"
           },
           6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
-            "key": "ledger_key_contract_instance",
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CBEPDNVYXQGWB5YUBXKJWYJA7OXTZW5LFLNO5JRRGE6Z6C5OSUZPCCEL",
-                "key": "ledger_key_contract_instance",
-                "durability": "persistent",
-                "val": {
-                  "contract_instance": {
-                    "executable": "stellar_asset",
-                    "storage": [
-                      {
-                        "key": {
-                          "symbol": "METADATA"
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "decimal"
-                              },
-                              "val": {
-                                "u32": 7
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "name"
-                              },
-                              "val": {
-                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEGWF"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "symbol"
-                              },
-                              "val": {
-                                "string": "aaa"
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "Admin"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "AssetInfo"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "symbol": "AlphaNum4"
-                            },
-                            {
-                              "map": [
-                                {
-                                  "key": {
-                                    "symbol": "asset_code"
-                                  },
-                                  "val": {
-                                    "string": "aaa\\0"
-                                  }
-                                },
-                                {
-                                  "key": {
-                                    "symbol": "issuer"
-                                  },
-                                  "val": {
-                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000002"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        }
-                      }
-                    ]
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          120960
         ]
       ],
       [

--- a/contract/test_snapshots/test/test_get_groups_by_creator.1.json
+++ b/contract/test_snapshots/test/test_get_groups_by_creator.1.json
@@ -1,13 +1,14 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0
   },
   "auth": [
     [],
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -21,13 +22,13 @@
                   "string": "Group 1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -38,7 +39,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -52,13 +53,13 @@
                   "string": "Group 2"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 2
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -86,10 +87,56 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "AllGroups"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllGroups"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0808080808080808080808080808080808080808080808080808080808080808"
+                    },
+                    {
+                      "bytes": "0909090909090909090909090909090909090909090909090909090909090909"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CreatorGroups"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -109,7 +156,7 @@
                       "symbol": "CreatorGroups"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -173,7 +220,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -205,7 +252,7 @@
                         "symbol": "payment_token"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -214,6 +261,14 @@
                       },
                       "val": {
                         "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "version"
+                      },
+                      "val": {
+                        "u32": 2
                       }
                     }
                   ]
@@ -267,7 +322,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -299,12 +354,20 @@
                         "symbol": "payment_token"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
                       "key": {
                         "symbol": "usage_count"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "version"
                       },
                       "val": {
                         "u32": 2
@@ -341,7 +404,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -354,7 +454,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -369,7 +469,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
@@ -387,7 +487,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 5541220902715666415
@@ -402,7 +502,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415

--- a/contract/test_snapshots/test/test_update_members.1.json
+++ b/contract/test_snapshots/test/test_update_members.1.json
@@ -1,13 +1,14 @@
 {
   "generators": {
-    "address": 5,
+    "address": 6,
     "nonce": 0
   },
   "auth": [
     [],
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -21,13 +22,13 @@
                   "string": "Team B"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -38,7 +39,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -49,7 +50,7 @@
                   "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "vec": [
@@ -60,7 +61,7 @@
                             "symbol": "address"
                           },
                           "val": {
-                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                           }
                         },
                         {
@@ -88,7 +89,7 @@
                             "symbol": "address"
                           },
                           "val": {
-                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                           }
                         },
                         {
@@ -137,10 +138,53 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "AllGroups"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllGroups"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CreatorGroups"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -160,7 +204,7 @@
                       "symbol": "CreatorGroups"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -221,7 +265,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -245,7 +289,7 @@
                                   "symbol": "address"
                                 },
                                 "val": {
-                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                                 }
                               },
                               {
@@ -273,7 +317,7 @@
                                   "symbol": "address"
                                 },
                                 "val": {
-                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                                 }
                               },
                               {
@@ -310,7 +354,7 @@
                         "symbol": "payment_token"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -319,6 +363,14 @@
                       },
                       "val": {
                         "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "version"
+                      },
+                      "val": {
+                        "u32": 2
                       }
                     }
                   ]
@@ -352,7 +404,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -365,7 +454,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -380,7 +469,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
@@ -398,7 +487,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 5541220902715666415
@@ -413,7 +502,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415

--- a/contract/test_snapshots/test/test_update_members_duplicate_member.1.json
+++ b/contract/test_snapshots/test/test_update_members_duplicate_member.1.json
@@ -1,13 +1,14 @@
 {
   "generators": {
-    "address": 4,
+    "address": 5,
     "nonce": 0
   },
   "auth": [
     [],
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -21,13 +22,13 @@
                   "string": "Team E"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -36,7 +37,6 @@
         }
       ]
     ],
-    [],
     []
   ],
   "ledger": {
@@ -56,10 +56,53 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "AllGroups"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllGroups"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0505050505050505050505050505050505050505050505050505050505050505"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CreatorGroups"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -79,7 +122,7 @@
                       "symbol": "CreatorGroups"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -140,7 +183,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -172,7 +215,7 @@
                         "symbol": "payment_token"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -181,6 +224,14 @@
                       },
                       "val": {
                         "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "version"
+                      },
+                      "val": {
+                        "u32": 2
                       }
                     }
                   ]
@@ -214,7 +265,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -227,7 +315,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -242,7 +330,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462

--- a/contract/test_snapshots/test/test_update_members_group_not_found.1.json
+++ b/contract/test_snapshots/test/test_update_members_group_not_found.1.json
@@ -1,9 +1,10 @@
 {
   "generators": {
-    "address": 5,
+    "address": 6,
     "nonce": 0
   },
   "auth": [
+    [],
     [],
     []
   ],
@@ -39,7 +40,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/contract/test_snapshots/test/test_update_members_invalid_percentage_too_low.1.json
+++ b/contract/test_snapshots/test/test_update_members_invalid_percentage_too_low.1.json
@@ -1,13 +1,14 @@
 {
   "generators": {
-    "address": 4,
+    "address": 5,
     "nonce": 0
   },
   "auth": [
     [],
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -21,13 +22,13 @@
                   "string": "Team C"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -56,10 +57,53 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "AllGroups"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllGroups"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CreatorGroups"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -79,7 +123,7 @@
                       "symbol": "CreatorGroups"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -140,7 +184,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -172,7 +216,7 @@
                         "symbol": "payment_token"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -181,6 +225,14 @@
                       },
                       "val": {
                         "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "version"
+                      },
+                      "val": {
+                        "u32": 2
                       }
                     }
                   ]
@@ -214,7 +266,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -227,7 +316,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -242,7 +331,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462

--- a/contract/test_snapshots/test/test_update_members_unauthorized.1.json
+++ b/contract/test_snapshots/test/test_update_members_unauthorized.1.json
@@ -1,13 +1,14 @@
 {
   "generators": {
-    "address": 5,
+    "address": 6,
     "nonce": 0
   },
   "auth": [
     [],
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
             "contract_fn": {
@@ -21,13 +22,13 @@
                   "string": "Team D"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "u32": 1
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -56,10 +57,53 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "AllGroups"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "AllGroups"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "bytes": "0404040404040404040404040404040404040404040404040404040404040404"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "CreatorGroups"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -79,7 +123,7 @@
                       "symbol": "CreatorGroups"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -140,7 +184,7 @@
                         "symbol": "creator"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                       }
                     },
                     {
@@ -172,7 +216,7 @@
                         "symbol": "payment_token"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -181,6 +225,14 @@
                       },
                       "val": {
                         "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "version"
+                      },
+                      "val": {
+                        "u32": 2
                       }
                     }
                   ]
@@ -214,7 +266,44 @@
                     "executable": {
                       "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                     },
-                    "storage": null
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "SchemaVersion"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
                   }
                 }
               }
@@ -227,7 +316,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -242,7 +331,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462


### PR DESCRIPTION
## Summary
Closes #123

This PR introduces contract upgradeability, schema versioning, resumable batched storage migration, and operational guardrails to the AutoShare Soroban contract.

## Context
Previously, group configurations were written directly to persistent storage without a schema version tag. Any schema modification would cause decoding failures and data loss on existing groups, and there was no mechanism to deploy bug fixes or upgrade the contract wasm on-chain.

## What Was Done

1. **WASM Upgrades (`upgrade`)**:
   - Implemented admin-gated `upgrade(env, caller, new_wasm_hash)` calling `env.deployer().update_current_contract_wasm(new_wasm_hash)`.
   - Gated with pause safety: `upgrade` is strictly rejected with `AutoShareError::ContractNotPaused` unless the contract is paused first.
   - Emits `("autoshare", "upgraded")` with the new WASM hash.

2. **Schema Versioning**:
   - Defined `CURRENT_SCHEMA_VERSION = 2` (v1 represents the implicit legacy layout).
   - Stored under `DataKey::SchemaVersion` in instance storage (read efficiently across calls).
   - Added `schema_version(env) -> u32` public view function.
   - Added one-time `init(env, admin)` to configure the administrator and stamp the initial version.

3. **Resumable Batched Migration (`migrate`)**:
   - Implemented admin-gated `migrate(env, caller, limit) -> Result<MigrationProgress, AutoShareError>`.
   - Iterates through groups using a persisted cursor in instance storage (`DataKey::MigrationCursor`).
   - Converts legacy 6-field `AutoShareDetailsV1` records into 7-field versioned `AutoShareDetails` records with `version: CURRENT_SCHEMA_VERSION`.
   - Emits `("autoshare", "migrated")` with `(migrated_count, remaining_count)`.
   - Automatically stamps `SchemaVersion` and removes `MigrationCursor` once `done == true`.
   - Returns `AutoShareError::NothingToMigrate` if called when already at the current version.

4. **Global Group Index (`DataKey::AllGroups`)**:
   - Maintained under `DataKey::AllGroups` on every `create` call to allow exhaustive migration without knowing creator addresses in advance.
   - **Write Cost & Entry Ceiling**: Storing `Vec<BytesN<32>>` in a single 64 KB persistent storage entry supports ~1,800–2,000 groups. Documented in `contract/README.md` along with scaling recommendations (paginated buckets like `AllGroupsPage(u32)`) for higher volume.

5. **Guardrails & Backward-Compatible Reads**:
   - While `schema_version() != CURRENT_SCHEMA_VERSION`, all mutating entrypoints (`create`, `update_members`, `distribute`) fail with `AutoShareError::MigrationRequired`.
   - Read-only entrypoints (`get`, `get_groups_by_creator`, `get_member_shares`, `get_total_percentage`) remain fully operational and backward-compatible by safely decoding both legacy (v1) and versioned (v2) group layouts.

6. **Pause / Unpause**:
   - Added admin-gated `pause(env, caller)` and `unpause(env, caller)` for safe maintenance windows.

7. **Documentation**:
   - Added a dedicated "Upgrades and migrations" section to `contract/README.md` containing the step-by-step operator runbook, rollback recovery rules, and global index scaling limits.

8. **Testing**:
   - Added full integration and lifecycle tests covering:
     - End-to-end upgrade lifecycle with v1 data retention.
     - 7 groups batched migration with limit = 3 in exactly 3 calls.
     - Interrupted migration consistency (reads succeed across both migrated and unmigrated groups).
     - Non-admin authorization rejections on `upgrade`, `migrate`, `pause`, and `unpause`.
     - Rejection of `upgrade` when unpaused.
     - `NothingToMigrate` when called on current schema.
   - All 41 unit and contract tests pass.