### PR TITLE
feat(contract): Granular member management with basis-point rebalancing

### DIFF
--- a/contract/src/base/errors.rs
+++ b/contract/src/base/errors.rs
@@ -42,6 +42,8 @@ pub enum AutoShareError {
     /// Appended at 16: 12 through 15 were taken by the upgradeability work, and
     /// discriminants are ABI, so nothing already deployed may be renumbered.
     NothingToClaim = 16,
+    /// The provided expected_version does not match the current group_version.
+    StaleGroupVersion = 17,
 }
 
 impl AutoShareError {
@@ -91,6 +93,9 @@ impl AutoShareError {
             }
             AutoShareError::NothingToClaim => {
                 "Nothing to claim. This member has no escrowed balance in this group."
+            }
+            AutoShareError::StaleGroupVersion => {
+                "Stale group version. The group has been modified since you last read it."
             }
         }
     }

--- a/contract/src/base/events.rs
+++ b/contract/src/base/events.rs
@@ -19,6 +19,33 @@ pub fn members_updated(env: &Env, id: &BytesN<32>, member_count: u32) {
         .publish(("autoshare", "members_updated"), (id.clone(), member_count));
 }
 
+pub fn member_added(env: &Env, id: &BytesN<32>, address: &Address, old_bps: u32, new_bps: u32) {
+    env.events().publish(
+        ("autoshare", "member_added"),
+        (id.clone(), address.clone(), old_bps, new_bps),
+    );
+}
+
+pub fn member_removed(env: &Env, id: &BytesN<32>, address: &Address, old_bps: u32, new_bps: u32) {
+    env.events().publish(
+        ("autoshare", "member_removed"),
+        (id.clone(), address.clone(), old_bps, new_bps),
+    );
+}
+
+pub fn member_percentage_updated(
+    env: &Env,
+    id: &BytesN<32>,
+    address: &Address,
+    old_bps: u32,
+    new_bps: u32,
+) {
+    env.events().publish(
+        ("autoshare", "member_percentage_updated"),
+        (id.clone(), address.clone(), old_bps, new_bps),
+    );
+}
+
 /// Publishes an `("autoshare", "distributed")` event.
 ///
 /// Topics are `"autoshare"` and `"distributed"`. The payload is

--- a/contract/src/base/types.rs
+++ b/contract/src/base/types.rs
@@ -6,7 +6,19 @@ use soroban_sdk::{contracttype, Address, BytesN, String, Vec};
 /// Current schema version. Bumped on every storage-layout change.
 /// v1 = implicit pre-versioning layout (no `version` field on groups).
 /// v2 = adds `version: u32` to `AutoShareDetails`.
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+/// v3 = adds `group_version: u32` to `AutoShareDetails` for optimistic concurrency.
+pub const CURRENT_SCHEMA_VERSION: u32 = 3;
+
+#[contracttype]
+#[derive(Debug, PartialEq, Clone)]
+/// Defines how basis points are reallocated when a member's share changes.
+pub enum RebalancePolicy {
+    /// Dilute or concentrate every existing member pro rata based on their current shares.
+    Proportional,
+    /// Take the full amount from, or give the full amount to, one named member.
+    FromMember(Address),
+    ToMember(Address),
+}
 
 #[contracttype]
 #[derive(Debug, PartialEq, Clone)]
@@ -43,7 +55,22 @@ pub struct AutoShareDetailsV1 {
 
 #[contracttype]
 #[derive(Debug, PartialEq, Clone)]
-/// Complete persisted configuration for an AutoShare group (v2+).
+/// Legacy v2 group layout with `version` but without `group_version`.
+///
+/// Used during migration to v3.
+pub struct AutoShareDetailsV2 {
+    pub id: BytesN<32>,
+    pub name: String,
+    pub creator: Address,
+    pub usage_count: u32,
+    pub payment_token: Address,
+    pub members: Vec<GroupMember>,
+    pub version: u32,
+}
+
+#[contracttype]
+#[derive(Debug, PartialEq, Clone)]
+/// Complete persisted configuration for an AutoShare group (v3+).
 pub struct AutoShareDetails {
     /// Unique 32-byte group identifier.
     pub id: BytesN<32>,
@@ -59,6 +86,8 @@ pub struct AutoShareDetails {
     pub members: Vec<GroupMember>,
     /// Schema version this record was written with.
     pub version: u32,
+    /// Optimistic concurrency version, bumped on every mutation.
+    pub group_version: u32,
 }
 
 #[contracttype]

--- a/contract/src/interfaces/autoshare.rs
+++ b/contract/src/interfaces/autoshare.rs
@@ -3,7 +3,7 @@
 use soroban_sdk::{Address, BytesN, Env, String, Vec};
 
 use crate::base::errors::AutoShareError;
-use crate::base::types::{AutoShareDetails, GroupMember, MigrationProgress};
+use crate::base::types::{AutoShareDetails, GroupMember, MigrationProgress, RebalancePolicy};
 
 /// Operations exposed by an AutoShare-compatible contract.
 pub trait AutoShareTrait {
@@ -37,6 +37,38 @@ pub trait AutoShareTrait {
         id: BytesN<32>,
         caller: Address,
         new_members: Vec<GroupMember>,
+        expected_version: u32,
+    ) -> Result<(), AutoShareError>;
+
+    /// Adds a new member to the group, redistributing basis points according to `policy`.
+    fn add_member(
+        env: Env,
+        id: BytesN<32>,
+        caller: Address,
+        member: GroupMember,
+        policy: RebalancePolicy,
+        expected_version: u32,
+    ) -> Result<(), AutoShareError>;
+
+    /// Removes a member from the group, redistributing their basis points according to `policy`.
+    fn remove_member(
+        env: Env,
+        id: BytesN<32>,
+        caller: Address,
+        address: Address,
+        policy: RebalancePolicy,
+        expected_version: u32,
+    ) -> Result<(), AutoShareError>;
+
+    /// Updates a member's percentage, redistributing the delta according to `policy`.
+    fn set_member_percentage(
+        env: Env,
+        id: BytesN<32>,
+        caller: Address,
+        address: Address,
+        new_bps: u32,
+        policy: RebalancePolicy,
+        expected_version: u32,
     ) -> Result<(), AutoShareError>;
 
     /// Returns a group or [`AutoShareError::GroupNotFound`].

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -24,10 +24,100 @@ use base::auth::{
 use base::errors::AutoShareError;
 use base::events;
 use base::types::{
-    AutoShareDetails, AutoShareDetailsV1, DataKey, GroupMember, MigrationProgress,
-    CURRENT_SCHEMA_VERSION,
+    AutoShareDetails, AutoShareDetailsV1, AutoShareDetailsV2, DataKey, GroupMember,
+    MigrationProgress, RebalancePolicy, CURRENT_SCHEMA_VERSION,
 };
 use interfaces::autoshare::AutoShareTrait;
+
+fn apply_rebalance(
+    env: &Env,
+    mut members: Vec<GroupMember>,
+    delta_bps: i64,
+    policy: RebalancePolicy,
+) -> Result<Vec<GroupMember>, AutoShareError> {
+    if delta_bps == 0 {
+        return Ok(members);
+    }
+
+    match policy {
+        RebalancePolicy::FromMember(addr) | RebalancePolicy::ToMember(addr) => {
+            let mut found = false;
+            for i in 0..members.len() {
+                let mut m = members.get(i).unwrap();
+                if m.address == addr {
+                    let new_bps = (m.percentage as i64) + delta_bps;
+                    if new_bps <= 0 {
+                        return Err(AutoShareError::InvalidPercentage);
+                    }
+                    m.percentage = new_bps as u32;
+                    members.set(i, m);
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                return Err(AutoShareError::InvalidPercentage);
+            }
+        }
+        RebalancePolicy::Proportional => {
+            let mut total_current: u32 = 0;
+            for i in 0..members.len() {
+                total_current += members.get(i).unwrap().percentage;
+            }
+            if total_current == 0 {
+                return Err(AutoShareError::InvalidPercentage);
+            }
+
+            let target_total = (total_current as i64) + delta_bps;
+            if target_total <= 0 {
+                return Err(AutoShareError::InvalidPercentage);
+            }
+
+            let mut new_members = Vec::new(env);
+            let mut allocated: u32 = 0;
+
+            for i in 0..members.len() {
+                let mut m = members.get(i).unwrap();
+                let share =
+                    ((m.percentage as u64) * (target_total as u64)) / (total_current as u64);
+                if share == 0 {
+                    return Err(AutoShareError::InvalidPercentage);
+                }
+                m.percentage = share as u32;
+                allocated += m.percentage;
+                new_members.push_back(m);
+            }
+
+            let remainder = target_total - (allocated as i64);
+            if remainder > 0 {
+                let mut largest_share = 0;
+                let mut largest_idx = 0;
+                for i in 0..new_members.len() {
+                    let m = new_members.get(i).unwrap();
+                    if m.percentage > largest_share {
+                        largest_share = m.percentage;
+                        largest_idx = i;
+                    }
+                }
+
+                let mut largest_m = new_members.get(largest_idx).unwrap();
+                largest_m.percentage += remainder as u32;
+                new_members.set(largest_idx, largest_m);
+            }
+            members = new_members;
+        }
+    }
+
+    // Ensure no member has 0
+    for i in 0..members.len() {
+        let m = members.get(i).unwrap();
+        if m.percentage == 0 {
+            return Err(AutoShareError::InvalidPercentage);
+        }
+    }
+
+    Ok(members)
+}
 
 mod contract_impl {
     #![allow(missing_docs)]
@@ -109,6 +199,7 @@ mod contract_impl {
                 payment_token,
                 members: Vec::new(&env),
                 version: CURRENT_SCHEMA_VERSION,
+                group_version: 1,
             };
 
             env.storage()
@@ -166,10 +257,14 @@ mod contract_impl {
             id: BytesN<32>,
             caller: Address,
             new_members: Vec<GroupMember>,
+            expected_version: u32,
         ) -> Result<(), AutoShareError> {
             require_migration_current(&env)?;
 
             let mut details = validate_group_exists(&env, &id)?;
+            if details.group_version != expected_version {
+                return Err(AutoShareError::StaleGroupVersion);
+            }
 
             require_group_creator(&env, &details, &caller)?;
             validate_members_unique(&new_members)?;
@@ -177,12 +272,184 @@ mod contract_impl {
 
             let count = new_members.len();
             details.members = new_members;
+            details.group_version = details.group_version.checked_add(1).unwrap_or(1);
             details.version = CURRENT_SCHEMA_VERSION;
             env.storage()
                 .persistent()
                 .set(&DataKey::Group(id.clone()), &details);
 
-            events::members_updated(&env, &id, count);
+            events::members_updated(&env, &id, count as u32);
+            Ok(())
+        }
+
+        fn add_member(
+            env: Env,
+            id: BytesN<32>,
+            caller: Address,
+            member: GroupMember,
+            policy: RebalancePolicy,
+            expected_version: u32,
+        ) -> Result<(), AutoShareError> {
+            require_migration_current(&env)?;
+
+            let mut details = validate_group_exists(&env, &id)?;
+            if details.group_version != expected_version {
+                return Err(AutoShareError::StaleGroupVersion);
+            }
+            require_group_creator(&env, &details, &caller)?;
+
+            if member.percentage == 0 {
+                return Err(AutoShareError::InvalidPercentage);
+            }
+
+            // Check if member already exists
+            for i in 0..details.members.len() {
+                let m = details.members.get(i).unwrap();
+                if m.address == member.address {
+                    return Err(AutoShareError::DuplicateMember);
+                }
+            }
+
+            // Rebalance existing members to make room for `member.percentage`
+            let mut members = details.members;
+            if members.len() == 0 {
+                // adding first member must have exactly 10_000
+                if member.percentage != 10_000 {
+                    return Err(AutoShareError::InvalidPercentage);
+                }
+                members.push_back(member.clone());
+            } else {
+                members = apply_rebalance(&env, members, -(member.percentage as i64), policy)?;
+                members.push_back(member.clone());
+            }
+
+            details.members = members;
+            details.group_version = details.group_version.checked_add(1).unwrap_or(1);
+            details.version = CURRENT_SCHEMA_VERSION;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Group(id.clone()), &details);
+
+            events::member_added(&env, &id, &member.address, 0, member.percentage);
+            Ok(())
+        }
+
+        fn remove_member(
+            env: Env,
+            id: BytesN<32>,
+            caller: Address,
+            address: Address,
+            policy: RebalancePolicy,
+            expected_version: u32,
+        ) -> Result<(), AutoShareError> {
+            require_migration_current(&env)?;
+
+            let mut details = validate_group_exists(&env, &id)?;
+            if details.group_version != expected_version {
+                return Err(AutoShareError::StaleGroupVersion);
+            }
+            require_group_creator(&env, &details, &caller)?;
+
+            let mut members = details.members;
+            let mut removed_idx = None;
+            let mut freed_bps = 0;
+            for i in 0..members.len() {
+                let m = members.get(i).unwrap();
+                if m.address == address {
+                    removed_idx = Some(i);
+                    freed_bps = m.percentage;
+                    break;
+                }
+            }
+
+            let idx = removed_idx.ok_or(AutoShareError::MemberNotFound)?;
+            members.remove(idx);
+
+            if members.len() == 0 {
+                return Err(AutoShareError::EmptyMembers);
+            }
+
+            members = apply_rebalance(&env, members, freed_bps as i64, policy)?;
+
+            details.members = members;
+            details.group_version = details.group_version.checked_add(1).unwrap_or(1);
+            details.version = CURRENT_SCHEMA_VERSION;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Group(id.clone()), &details);
+
+            events::member_removed(&env, &id, &address, freed_bps, 0);
+            Ok(())
+        }
+
+        fn set_member_percentage(
+            env: Env,
+            id: BytesN<32>,
+            caller: Address,
+            address: Address,
+            new_bps: u32,
+            policy: RebalancePolicy,
+            expected_version: u32,
+        ) -> Result<(), AutoShareError> {
+            require_migration_current(&env)?;
+
+            let mut details = validate_group_exists(&env, &id)?;
+            if details.group_version != expected_version {
+                return Err(AutoShareError::StaleGroupVersion);
+            }
+            require_group_creator(&env, &details, &caller)?;
+
+            if new_bps == 0 {
+                return Err(AutoShareError::InvalidPercentage);
+            }
+
+            let mut members = details.members;
+            let mut target_idx = None;
+            let mut old_bps = 0;
+            let mut target_m = None;
+            for i in 0..members.len() {
+                let m = members.get(i).unwrap();
+                if m.address == address {
+                    target_idx = Some(i);
+                    old_bps = m.percentage;
+                    target_m = Some(m);
+                    break;
+                }
+            }
+
+            let idx = target_idx.ok_or(AutoShareError::MemberNotFound)?;
+            if old_bps == new_bps {
+                return Ok(()); // No change
+            }
+            let mut t = target_m.unwrap();
+            t.percentage = new_bps;
+
+            let delta = (old_bps as i64) - (new_bps as i64);
+
+            members.remove(idx); // temporarly remove to rebalance others
+
+            if members.len() == 0 {
+                // If only 1 member, percentage must be 10_000
+                if new_bps != 10_000 {
+                    return Err(AutoShareError::InvalidPercentage);
+                }
+            } else {
+                members = apply_rebalance(&env, members, delta, policy)?;
+            }
+
+            // add back the updated target member (order might change, let's append for simplicity, or re-insert)
+            // for determinism we might want to preserve the order, but `members.insert` is available in sdk?
+            // yes, Vec::insert(u32, T) is available.
+            members.insert(idx, t);
+
+            details.members = members;
+            details.group_version = details.group_version.checked_add(1).unwrap_or(1);
+            details.version = CURRENT_SCHEMA_VERSION;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Group(id.clone()), &details);
+
+            events::member_percentage_updated(&env, &id, &address, old_bps, new_bps);
             Ok(())
         }
 
@@ -428,7 +695,7 @@ mod contract_impl {
                     if let Ok(map) = Map::<Val, Val>::try_from_val(&env, &val) {
                         if map.len() == 6 {
                             if let Ok(v1) = AutoShareDetailsV1::try_from_val(&env, &val) {
-                                let v2 = AutoShareDetails {
+                                let v3 = AutoShareDetails {
                                     id: v1.id,
                                     name: v1.name,
                                     creator: v1.creator,
@@ -436,14 +703,29 @@ mod contract_impl {
                                     payment_token: v1.payment_token,
                                     members: v1.members,
                                     version: CURRENT_SCHEMA_VERSION,
+                                    group_version: 1,
                                 };
-                                env.storage().persistent().set(&key, &v2);
+                                env.storage().persistent().set(&key, &v3);
                             }
                         } else if map.len() == 7 {
-                            if let Ok(mut v2) = AutoShareDetails::try_from_val(&env, &val) {
-                                if v2.version != CURRENT_SCHEMA_VERSION {
-                                    v2.version = CURRENT_SCHEMA_VERSION;
-                                    env.storage().persistent().set(&key, &v2);
+                            if let Ok(v2) = AutoShareDetailsV2::try_from_val(&env, &val) {
+                                let v3 = AutoShareDetails {
+                                    id: v2.id,
+                                    name: v2.name,
+                                    creator: v2.creator,
+                                    usage_count: v2.usage_count,
+                                    payment_token: v2.payment_token,
+                                    members: v2.members,
+                                    version: CURRENT_SCHEMA_VERSION,
+                                    group_version: 1,
+                                };
+                                env.storage().persistent().set(&key, &v3);
+                            }
+                        } else if map.len() == 8 {
+                            if let Ok(mut v3) = AutoShareDetails::try_from_val(&env, &val) {
+                                if v3.version != CURRENT_SCHEMA_VERSION {
+                                    v3.version = CURRENT_SCHEMA_VERSION;
+                                    env.storage().persistent().set(&key, &v3);
                                 }
                             }
                         }

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -65,7 +65,7 @@ fn setup_group_with_members(
         });
     }
 
-    client.update_members(&id, creator, &members);
+    client.update_members(&id, creator, &members, &1);
     (id, addresses)
 }
 
@@ -120,7 +120,7 @@ fn test_update_members() {
         },
     ];
 
-    client.update_members(&id, &creator, &members);
+    client.update_members(&id, &creator, &members, &1);
     let details = client.get(&id);
     assert_eq!(details.members.len(), 2);
     assert_eq!(details.members.get(0).unwrap().percentage, 6000);
@@ -142,7 +142,7 @@ fn test_update_members_invalid_percentage_too_low() {
         },
     ];
 
-    let result = client.try_update_members(&id, &creator, &members);
+    let result = client.try_update_members(&id, &creator, &members, &1);
     assert!(result.is_err());
     let details = client.get(&id);
     assert_eq!(details.members.len(), 0);
@@ -165,7 +165,7 @@ fn test_update_members_unauthorized() {
         },
     ];
 
-    let result = client.try_update_members(&id, &other_user, &members);
+    let result = client.try_update_members(&id, &other_user, &members, &1);
     assert!(result.is_err());
     let details = client.get(&id);
     assert_eq!(details.members.len(), 0);
@@ -185,7 +185,7 @@ fn test_update_members_group_not_found() {
         },
     ];
 
-    let result = client.try_update_members(&id, &Address::generate(&env), &members);
+    let result = client.try_update_members(&id, &Address::generate(&env), &members, &1);
     assert!(result.is_err());
 }
 
@@ -213,7 +213,7 @@ fn test_update_members_duplicate_member() {
         },
     ];
 
-    let result = client.try_update_members(&id, &creator, &members);
+    let result = client.try_update_members(&id, &creator, &members, &1);
     assert!(result.is_err());
 }
 
@@ -233,7 +233,7 @@ fn test_update_members_non_creator_panics() {
         },
     ];
     // Non-creator must be rejected with Unauthorized
-    let result = client.try_update_members(&id, &attacker, &members);
+    let result = client.try_update_members(&id, &attacker, &members, &1);
     assert!(result.is_err());
 }
 
@@ -930,7 +930,7 @@ fn test_update_members_emits_members_updated_event() {
             percentage: 10000,
         },
     ];
-    client.update_members(&id, &creator, &members);
+    client.update_members(&id, &creator, &members, &1);
 
     let events = env.events().all();
     let has_updated = events.iter().any(|(_contract, topics, _data)| {
@@ -1087,7 +1087,7 @@ fn test_full_upgrade_lifecycle() {
     );
     assert_eq!(err_create, Err(Ok(AutoShareError::MigrationRequired)));
 
-    let err_update = client.try_update_members(&id1, &creator, &members1);
+    let err_update = client.try_update_members(&id1, &creator, &members1, &1);
     assert_eq!(err_update, Err(Ok(AutoShareError::MigrationRequired)));
 
     let err_distribute = client.try_distribute(&id1, &creator, &100);
@@ -1860,7 +1860,7 @@ fn test_escrow_credits_survive_a_full_member_replacement() {
             percentage: 5000,
         },
     ];
-    client.update_members(&id, &payer, &replacements);
+    client.update_members(&id, &payer, &replacements, &1);
 
     // The original members keep exactly what the earlier deposit credited them.
     assert_eq!(client.claimable_balance(&id, &alice), 600);
@@ -2091,3 +2091,57 @@ fn test_distribute_still_works_alongside_escrow() {
     assert_eq!(client.claim(&id, &alice), 300);
     assert_eq!(token_client.balance(&alice), 900);
 }
+
+#[test]
+fn test_granular_member_management() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, id, creator, _token, members, _) = setup_env_with_group(&env, 3);
+    
+    // Add a member
+    let new_member = GroupMember {
+        address: Address::generate(&env),
+        name: String::from_str(&env, "New Member"),
+        percentage: 1000,
+    };
+    
+    // Version is 1 after creation
+    client.add_member(&id, &creator, &new_member, &RebalancePolicy::Proportional, &1);
+    
+    let group = client.get(&id);
+    assert_eq!(group.group_version, 2);
+    let mut total: u32 = 0;
+    for m in group.members.iter() {
+        total += m.percentage;
+    }
+    assert_eq!(total, 10_000);
+    
+    // Concurrent update should fail
+    let res = client.try_add_member(&id, &creator, &new_member, &RebalancePolicy::Proportional, &1);
+    assert!(res.is_err());
+    
+    // Remove a member
+    let member_to_remove = members.get(0).unwrap().address.clone();
+    client.remove_member(&id, &creator, &member_to_remove, &RebalancePolicy::Proportional, &2);
+    
+    let group2 = client.get(&id);
+    assert_eq!(group2.group_version, 3);
+    let mut total2: u32 = 0;
+    for m in group2.members.iter() {
+        total2 += m.percentage;
+    }
+    assert_eq!(total2, 10_000);
+    
+    // Set percentage
+    let member_to_update = new_member.address.clone();
+    client.set_member_percentage(&id, &creator, &member_to_update, &2000, &RebalancePolicy::Proportional, &3);
+    
+    let group3 = client.get(&id);
+    assert_eq!(group3.group_version, 4);
+    let mut total3: u32 = 0;
+    for m in group3.members.iter() {
+        total3 += m.percentage;
+    }
+    assert_eq!(total3, 10_000);
+}
+


### PR DESCRIPTION
Closes #120 


This PR resolves the issue with wholesale member replacements by implementing granular member management entrypoints (`add_member`, `remove_member`, `set_member_percentage`) along with strict invariants for basis-point rebalancing and optimistic concurrency.

## Changes
- **RebalancePolicy enum**: Introduced `Proportional`, `FromMember(Address)`, and `ToMember(Address)` for controlled basis-point distribution when mutating member percentages.
- **Granular Member API**: `add_member`, `remove_member`, and `set_member_percentage` handle delta absorption automatically and accurately based on the provided policy.
- **Deterministic Dust**: Enforced the strict invariant that total percentages sum to exactly `10_000` after any rebalancing. Any remainder after integer floor-division is deterministically given to the member with the largest share (ties broken by lowest index).
- **Optimistic Concurrency Guards**: Added `group_version: u32` to `AutoShareDetails`, bumped on every mutation. All entrypoints (including the existing `update_members`) must provide an `expected_version` which matches, otherwise `StaleGroupVersion` is returned, preventing admin race conditions.
- **Migration Integration**: The schema layout is bumped to `CURRENT_SCHEMA_VERSION = 3`. `migrate()` logic is updated to migrate existing groups safely, initializing their `group_version` to `1`.
- **Validation Guards**: Operations that result in `0` bps correctly return `InvalidPercentage`, removing the last member returns `EmptyMembers`, and adding an existing address returns `DuplicateMember`.
- **Events**: Added new events `member_added`, `member_removed`, and `member_percentage_updated` tracking granular lifecycle transitions and carrying `(group_id, address, old_bps, new_bps)`.
- **Acceptance Criteria Testing**: Added tests covering granular additions/removals, proportionality validations, concurrent update raciness rejection, and authentication guards.