### PR TITLE
Group creation function with validation

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -207,6 +207,10 @@ mod contract_impl {
         /// The `creator` must authorize the call. The group is stored under `id`,
         /// indexed under the creator's address, and added to the global group index.
         ///
+        /// This is the group-creation entrypoint: the caller supplies a unique
+        /// `id` up front (rather than the contract generating one), so `create`
+        /// rejects a reused `id` instead of returning a freshly minted one.
+        ///
         /// # Parameters
         ///
         /// - `env`: Soroban execution environment.


### PR DESCRIPTION
The create function in contract/src/lib.rs already implements group creation with validation, duplicate-id rejection, and GroupCreated event emission, with test coverage in contract/src/test.rs. Added a doc-comment note clarifying the id scheme.

Closes #58