### PR TITLE
Define contract event types for group operations

### DIFF
--- a/contract/src/base/events.rs
+++ b/contract/src/base/events.rs
@@ -1,22 +1,73 @@
 //! Event publishers for contract state changes and token distributions.
 
-use soroban_sdk::{Address, BytesN, Env};
+use soroban_sdk::{contracttype, Address, BytesN, Env};
+
+/// Emitted when a new AutoShare group is created.
+#[contracttype]
+#[derive(Debug, PartialEq, Clone)]
+pub struct GroupCreated {
+    /// Identifier of the newly created group.
+    pub group_id: BytesN<32>,
+    /// Address that created the group.
+    pub creator: Address,
+    /// Token contract configured for the group's distributions.
+    pub token: Address,
+    /// Ledger timestamp at which the group was created.
+    pub timestamp: u64,
+}
+
+/// Emitted when a group's member list is replaced.
+#[contracttype]
+#[derive(Debug, PartialEq, Clone)]
+pub struct MembersUpdated {
+    /// Identifier of the updated group.
+    pub group_id: BytesN<32>,
+    /// Number of members in the group after the update.
+    pub member_count: u32,
+    /// Ledger timestamp at which the update occurred.
+    pub timestamp: u64,
+}
+
+/// Emitted when a distribution has been paid out to a group's members.
+#[contracttype]
+#[derive(Debug, PartialEq, Clone)]
+pub struct DistributionProcessed {
+    /// Identifier of the group the distribution was processed for.
+    pub group_id: BytesN<32>,
+    /// Total amount distributed across the group's members.
+    pub total_amount: i128,
+    /// Ledger timestamp at which the distribution was processed.
+    pub timestamp: u64,
+}
 
 /// Publishes an `("autoshare", "created")` event.
 ///
-/// Topics are `"autoshare"` and `"created"`. The payload is `(id, creator)`.
-pub fn group_created(env: &Env, id: &BytesN<32>, creator: &Address) {
-    env.events()
-        .publish(("autoshare", "created"), (id.clone(), creator.clone()));
+/// Topics are `"autoshare"` and `"created"`. The payload is a [`GroupCreated`].
+pub fn group_created(env: &Env, id: &BytesN<32>, creator: &Address, token: &Address) {
+    env.events().publish(
+        ("autoshare", "created"),
+        GroupCreated {
+            group_id: id.clone(),
+            creator: creator.clone(),
+            token: token.clone(),
+            timestamp: env.ledger().timestamp(),
+        },
+    );
 }
 
 /// Publishes an `("autoshare", "members_updated")` event.
 ///
-/// Topics are `"autoshare"` and `"members_updated"`. The payload is
-/// `(id, member_count)`.
+/// Topics are `"autoshare"` and `"members_updated"`. The payload is a
+/// [`MembersUpdated`].
 pub fn members_updated(env: &Env, id: &BytesN<32>, member_count: u32) {
-    env.events()
-        .publish(("autoshare", "members_updated"), (id.clone(), member_count));
+    env.events().publish(
+        ("autoshare", "members_updated"),
+        MembersUpdated {
+            group_id: id.clone(),
+            member_count,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
 }
 
 /// Publishes an `("autoshare", "member_added")` event.
@@ -51,12 +102,16 @@ pub fn member_percentage_updated(
 
 /// Publishes an `("autoshare", "distributed")` event.
 ///
-/// Topics are `"autoshare"` and `"distributed"`. The payload is
-/// `(id, from, amount)`.
-pub fn distributed(env: &Env, id: &BytesN<32>, from: &Address, amount: i128) {
+/// Topics are `"autoshare"` and `"distributed"`. The payload is a
+/// [`DistributionProcessed`].
+pub fn distributed(env: &Env, id: &BytesN<32>, total_amount: i128) {
     env.events().publish(
         ("autoshare", "distributed"),
-        (id.clone(), from.clone(), amount),
+        DistributionProcessed {
+            group_id: id.clone(),
+            total_amount,
+            timestamp: env.ledger().timestamp(),
+        },
     );
 }
 

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -274,7 +274,7 @@ mod contract_impl {
             all_ids.push_back(id.clone());
             env.storage().persistent().set(&all_groups_key, &all_ids);
 
-            events::group_created(&env, &id, &creator);
+            events::group_created(&env, &id, &creator, &details.payment_token);
             Ok(())
         }
 
@@ -594,7 +594,7 @@ mod contract_impl {
                 }
             }
 
-            events::distributed(&env, &id, &from, amount);
+            events::distributed(&env, &id, amount);
             Ok(())
         }
 

--- a/contract/src/test.rs
+++ b/contract/src/test.rs
@@ -3,7 +3,7 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events as _, Ledger as _},
-    vec, Address, BytesN, Env, String, Vec,
+    vec, Address, BytesN, Env, String, TryFromVal, Vec,
 };
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -1034,6 +1034,138 @@ fn test_distribute_emits_distributed_event() {
         has_distributed,
         "expected distributed event was not emitted"
     );
+}
+
+#[test]
+fn test_create_event_payload_has_expected_fields() {
+    let (env, client, creator, token) = setup_env();
+    let id = BytesN::from_array(&env, &[82u8; 32]);
+
+    client.create(
+        &id,
+        &String::from_str(&env, "Payload Group"),
+        &creator,
+        &1,
+        &token,
+    );
+
+    let events = env.events().all();
+    let payload = events
+        .iter()
+        .find_map(|(_contract, topics, data)| {
+            let is_created = topics
+                == soroban_sdk::vec![
+                    &env,
+                    soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(
+                        &String::from_str(&env, "autoshare"),
+                        &env
+                    ),
+                    soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(
+                        &String::from_str(&env, "created"),
+                        &env
+                    ),
+                ];
+            if is_created {
+                base::events::GroupCreated::try_from_val(&env, &data).ok()
+            } else {
+                None
+            }
+        })
+        .expect("expected GroupCreated event payload");
+
+    assert_eq!(payload.group_id, id);
+    assert_eq!(payload.creator, creator);
+    assert_eq!(payload.token, token);
+}
+
+#[test]
+fn test_update_members_event_payload_has_expected_fields() {
+    let (env, client, creator, token) = setup_env();
+    let id = BytesN::from_array(&env, &[83u8; 32]);
+
+    client.create(
+        &id,
+        &String::from_str(&env, "Payload Group 2"),
+        &creator,
+        &1,
+        &token,
+    );
+
+    let members = vec![
+        &env,
+        GroupMember {
+            address: Address::generate(&env),
+            name: String::from_str(&env, "Alice"),
+            percentage: 10000,
+        },
+    ];
+    client.update_members(&id, &creator, &members, &1);
+
+    let events = env.events().all();
+    let payload = events
+        .iter()
+        .find_map(|(_contract, topics, data)| {
+            let is_updated = topics
+                == soroban_sdk::vec![
+                    &env,
+                    soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(
+                        &String::from_str(&env, "autoshare"),
+                        &env
+                    ),
+                    soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(
+                        &String::from_str(&env, "members_updated"),
+                        &env
+                    ),
+                ];
+            if is_updated {
+                base::events::MembersUpdated::try_from_val(&env, &data).ok()
+            } else {
+                None
+            }
+        })
+        .expect("expected MembersUpdated event payload");
+
+    assert_eq!(payload.group_id, id);
+    assert_eq!(payload.member_count, 1);
+}
+
+#[test]
+fn test_distribute_event_payload_has_expected_fields() {
+    let (env, client, creator, token_address) = setup_token_env();
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_address);
+    token_admin.mint(&creator, &500);
+
+    let (id, _) =
+        setup_group_with_members(&env, &client, &creator, &token_address, 70, &[5000, 5000]);
+
+    client.distribute(&id, &creator, &500);
+
+    let events = env.events().all();
+    let payload = events
+        .iter()
+        .find_map(|(_contract, topics, data)| {
+            let is_distributed = topics
+                == soroban_sdk::vec![
+                    &env,
+                    soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(
+                        &String::from_str(&env, "autoshare"),
+                        &env
+                    ),
+                    soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(
+                        &String::from_str(&env, "distributed"),
+                        &env
+                    ),
+                ];
+            if is_distributed {
+                base::events::DistributionProcessed::try_from_val(&env, &data).ok()
+            } else {
+                None
+            }
+        })
+        .expect("expected DistributionProcessed event payload");
+
+    assert_eq!(payload.group_id, id);
+    assert_eq!(payload.total_amount, 500);
 }
 
 // ── upgrade & migration tests ────────────────────────────────────────────────


### PR DESCRIPTION
- #56: Defined typed GroupCreated, MembersUpdated, and DistributionProcessed contract events in contract/src/base/events.rs, each carrying a ledger timestamp, and wired them into the create, update_members, and distribute contract functions.

Closes #56